### PR TITLE
Add detailed failure information to JUnit output

### DIFF
--- a/src/JUnitOutputDriver.cpp
+++ b/src/JUnitOutputDriver.cpp
@@ -17,8 +17,7 @@ JUnitOutputDriver::JUnitOutputDriver(void *data) : StdOutputDriver(data),
     std::stringstream results_log_name;
     results_log_name << "test_results" << getpid() << ".xml";
     streams[HUMAN] = results_log_name.str();
-
-    log(HUMAN, "<testsuites>\n");
+   log(HUMAN, "<testsuites>\n");
 }
 
 JUnitOutputDriver::~JUnitOutputDriver() {
@@ -50,6 +49,7 @@ void JUnitOutputDriver::startNewTest(std::map <std::string, std::string> &attrib
         group_errors= 0;
         group_tests = 0;
     }
+    failure_log.clear();
     StdOutputDriver::startNewTest(attributes, test, group);
 }
 
@@ -77,7 +77,7 @@ void JUnitOutputDriver::logResult(test_results_t result, int stage)
             break;
 
         case FAILED:
-            group_output << ">\n<failure>Test failed</failure>\n";
+            group_output << ">\n<failure>" << failure_log.str() << "</failure>\n";
             group_failures++;
             group_output << "</testcase>";
             break;
@@ -102,6 +102,20 @@ void JUnitOutputDriver::logResult(test_results_t result, int stage)
             // do nothing
     }
 
+}
+
+void JUnitOutputDriver::vlog(TestOutputStream stream, const char *fmt, va_list args)
+{
+    if(stream == LOGERR)
+    {
+        char tmp[256];
+        vsnprintf(tmp, 256, fmt, args );
+        failure_log << tmp;
+    }
+    else
+    {
+        StdOutputDriver::vlog(stream, fmt, args);
+    }
 }
 void JUnitOutputDriver::finalizeOutput()
 {

--- a/src/JUnitOutputDriver.h
+++ b/src/JUnitOutputDriver.h
@@ -24,13 +24,15 @@ public:
 
     virtual void logResult(test_results_t result, int stage=-1);
     virtual void finalizeOutput();
+    virtual void vlog(TestOutputStream stream, const char *fmt, va_list args);
 
- private:
+private:
     int group_failures;
     int group_skips;
     int group_errors;
     int group_tests;
     std::stringstream group_output;
+    std::stringstream failure_log;
 };
 
 


### PR DESCRIPTION
Sends all logerror entries to the contents of the <failure> tag (if present). Should provide better error reports.