### PR TITLE
Fix test_callback_2 and test_thread_5

### DIFF
--- a/src/dyninst/test12.h
+++ b/src/dyninst/test12.h
@@ -57,6 +57,7 @@
 #define MUTEX_LOCK_FUNC "pthread_mutex_lock"
 #define MUTEX_UNLOCK_FUNC "pthread_mutex_unlock"
 #define MUTEX_DESTROY_FUNC "pthread_mutex_destroy"
+#include <stdint.h>
 #endif
 typedef enum {
    null_event = 3,
@@ -73,9 +74,10 @@ typedef enum {
 } user_event_t;
 
 typedef struct {
-  unsigned int id;
-  user_event_t what; 
-  unsigned long tid;
+
+  uint32_t id;
+  user_event_t what;
+  uint64_t tid;
 } user_msg_t;
 
 #endif


### PR DESCRIPTION
Fix message struct to use defined stdint types rather than assuming that ints, longs, etc are the same on mutator and mutatee side.