### PR TITLE
Do not count the vDSO object at run time

### DIFF
--- a/src/proccontrol/pc_tls_mutatee.c
+++ b/src/proccontrol/pc_tls_mutatee.c
@@ -38,6 +38,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <assert.h>
 #include "pcontrol_mutatee_tools.h"
 #include "solo_mutatee_boilerplate.h"
@@ -69,7 +70,7 @@ static unsigned int lib_count = 0;
 int cb(struct dl_phdr_info *info, size_t size, void *v)
 {
    (void) info; (void) size; (void) v;
-   lib_count++;
+   if (strstr(info->dlpi_name, "linux-vdso.so.1") != NULL) lib_count++;
    return 0;
 }
 


### PR DESCRIPTION
This is needed so that pc_tls static tests finish successfully, tested on arm64, but suppose
work on other architectures as well.

```
$ ./test_driver -test pc_tls -all
TEST                       COMP   OPT  ABI MODE     THREAD  LINK    PIC     RESULT
pc_tls                     g++    none 64  create   SPST    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  create   MPST    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  create   SPMT    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  create   MPMT    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  attach   SPST    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  attach   MPST    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  attach   SPMT    dynamic nonPIC  PASSED
pc_tls                     g++    none 64  attach   MPMT    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  create   SPST    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  create   MPST    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  create   SPMT    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  create   MPMT    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  attach   SPST    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  attach   MPST    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  attach   SPMT    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  attach   MPMT    dynamic nonPIC  PASSED
pc_tls                     gcc    none 64  create   SPST    static  nonPIC  PASSED
pc_tls                     gcc    none 64  create   MPST    static  nonPIC  PASSED
pc_tls                     gcc    none 64  create   SPMT    static  nonPIC  PASSED
pc_tls                     gcc    none 64  create   MPMT    static  nonPIC  PASSED
pc_tls                     gcc    none 64  attach   SPST    static  nonPIC  PASSED
pc_tls                     gcc    none 64  attach   MPST    static  nonPIC  PASSED
pc_tls                     gcc    none 64  attach   SPMT    static  nonPIC  PASSED
pc_tls                     gcc    none 64  attach   MPMT    static  nonPIC  PASSED
```