### PR TITLE
Remove test_symtab_ser_funcs test from the set of SymtabAPI tests

### DIFF
--- a/src/JUnitOutputDriver.h
+++ b/src/JUnitOutputDriver.h
@@ -27,7 +27,7 @@ struct RungroupResults
 
     xmlNodePtr add_test(const char* class_name, const char* test_name, float cpu_usage) {
         xmlNodePtr curTest = xmlNewChild(group_node, NULL, BAD_CAST "testcase", NULL);
-        xmlSetProp(curTest, BAD_CAST  "class", BAD_CAST class_name);
+        xmlSetProp(curTest, BAD_CAST  "classname", BAD_CAST class_name);
         xmlSetProp(curTest, BAD_CAST  "name", BAD_CAST test_name);
         std::stringstream t;
         t << cpu_usage;

--- a/src/instruction/aarch64_decode.C
+++ b/src/instruction/aarch64_decode.C
@@ -470,7 +470,7 @@ test_results_t aarch64_decode_Mutator::executeTest()
   RegisterAST::Ptr b30(new RegisterAST(aarch64::b30));
   RegisterAST::Ptr b31(new RegisterAST(aarch64::b31));
 
-  RegisterAST::Ptr zr (new RegisterAST(aarch64::zr));
+  RegisterAST::Ptr zr (new RegisterAST(aarch64::xzr));
   RegisterAST::Ptr wzr (new RegisterAST(aarch64::wzr));
   RegisterAST::Ptr sp (new RegisterAST(aarch64::sp));
   RegisterAST::Ptr wsp (new RegisterAST(aarch64::wsp));

--- a/src/instruction/aarch64_decode_ldst.C
+++ b/src/instruction/aarch64_decode_ldst.C
@@ -526,7 +526,7 @@ test_results_t aarch64_decode_ldst_Mutator::executeTest()
   RegisterAST::Ptr b30(new RegisterAST(aarch64::b30));
   RegisterAST::Ptr b31(new RegisterAST(aarch64::b31));
 
-  RegisterAST::Ptr zr (new RegisterAST(aarch64::zr));
+  RegisterAST::Ptr zr (new RegisterAST(aarch64::xzr));
   RegisterAST::Ptr wzr (new RegisterAST(aarch64::wzr));
   RegisterAST::Ptr sp (new RegisterAST(aarch64::sp));
   RegisterAST::Ptr wsp (new RegisterAST(aarch64::wsp));

--- a/src/instruction/aarch64_simd.C
+++ b/src/instruction/aarch64_simd.C
@@ -249,7 +249,7 @@ test_results_t aarch64_simd_Mutator::executeTest()
 	return FAILED;
     }
 
-    RegisterAST::Ptr zr (new RegisterAST(aarch64::zr));
+    RegisterAST::Ptr zr (new RegisterAST(aarch64::xzr));
     RegisterAST::Ptr wzr (new RegisterAST(aarch64::wzr));
 
     RegisterAST::Ptr x0 (new RegisterAST(aarch64::x0));


### PR DESCRIPTION
This fixes the Issue#22. Please merge.