### PR TITLE
Avoid having initial declaration in 'for' loop (a C99 feature)

### DIFF
--- a/src/dyninst/test1.h
+++ b/src/dyninst/test1.h
@@ -34,7 +34,8 @@
 unsigned long get_pointer()
 {
     unsigned long val;
-    for(short i = 0; i < sizeof(void *); i++) {
+    short i;
+    for(i = 0; i < sizeof(void *); i++) {
         val = (val << 8)|((i&0xFF)|0xA0);
     }
     return val;


### PR DESCRIPTION
Putting the initialization in the 'for' loop is a C99 language
specification feature.  GCC will flag its use as an error unless using
C99 mode.  For this particular case there is really nothing to be
gained by using it.  Moved the declaration to the beginning of the
function.

Signed-off-by: William Cohen <wcohen@redhat.com>