### PR TITLE
Fix Instruction refererences for i386

### DIFF
--- a/src/instruction/test_instruction_farcall.C
+++ b/src/instruction/test_instruction_farcall.C
@@ -96,21 +96,21 @@ test_results_t test_instruction_farcall_Mutator::executeTest()
   if(decodedInsns.size() != expectedInsns) // six valid, one invalid
   {
     logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-    for(std::vector<Instruction::Ptr>::iterator curInsn = decodedInsns.begin();
+    for(std::vector<Instruction>::iterator curInsn = decodedInsns.begin();
 	curInsn != decodedInsns.end();
 	++curInsn)
     {
-      logerror("\t%s\t", (*curInsn)->format().c_str());
-      for(unsigned j = 0; j < (*curInsn)->size(); ++j)
+      logerror("\t%s\t", (*curInsn).format().c_str());
+      for(unsigned j = 0; j < (*curInsn).size(); ++j)
       {
-	logerror("%x ", (*curInsn)->rawByte(j));
+	logerror("%x ", (*curInsn).rawByte(j));
       }
       logerror("\n");
     }
     
     return FAILED;
   }
-  if(decodedInsns.back() && decodedInsns.back()->isValid())
+  if(decodedInsns.size() > 0 && decodedInsns.back().isValid())
   {
     logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
     return FAILED;


### PR DESCRIPTION
Fedora releases always build on i386.  This fixes a problem building dyninst-testsuite on i386