### PR TITLE
Don't allow running the Testsuite without building it first in build script.

### DIFF
--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -94,6 +94,12 @@ use Dyninst::utils;
 			print "The Testsuite in '$args{'restart'}' must be rebuilt\n";
 			exit 1;
 		}
+	} else {
+		if($args{'run-tests'} && !$args{'build-tests'}) {
+			print "The Testsuite must be built before it can be run. ",
+			      "Use --restart to reuse a previous build.\n";
+			exit 1;
+		}
 	}
 
 	# Save a backup, if the log file already exists
@@ -138,19 +144,17 @@ use Dyninst::utils;
 	
 	eval {
 		# Testsuite
-		if($args{'tests'}) {
-			# Always set up logs, even if doing a restart
-			my ($base_dir, $build_dir) = Dyninst::testsuite::setup($root_dir, \%args, $fdLog);
-
-			if($args{'build-tests'}) {
-				Dyninst::logs::write($fdLog, !$args{'quiet'}, "Configuring Testsuite... ");
-				Dyninst::testsuite::configure(\%args, $base_dir, $build_dir);
-				Dyninst::logs::write($fdLog, !$args{'quiet'}, "done\n");
-				
-				Dyninst::logs::write($fdLog, !$args{'quiet'}, "Building Testsuite... ");
-				Dyninst::testsuite::build(\%args, $build_dir);
-				Dyninst::logs::write($fdLog, !$args{'quiet'}, "done\n");
-			}
+		# Always set up logs, even if doing a restart
+		my ($base_dir, $build_dir) = Dyninst::testsuite::setup($root_dir, \%args, $fdLog);
+		
+		if($args{'build-tests'}) {
+			Dyninst::logs::write($fdLog, !$args{'quiet'}, "Configuring Testsuite... ");
+			Dyninst::testsuite::configure(\%args, $base_dir, $build_dir);
+			Dyninst::logs::write($fdLog, !$args{'quiet'}, "done\n");
+			
+			Dyninst::logs::write($fdLog, !$args{'quiet'}, "Building Testsuite... ");
+			Dyninst::testsuite::build(\%args, $build_dir);
+			Dyninst::logs::write($fdLog, !$args{'quiet'}, "done\n");
 		}
 	};
 	if($@) {


### PR DESCRIPTION
This makes the combination of `--no-build-tests --run-tests` illegal.

There are possibly more corner cases I've missed, but I've tried to fuzz test as best I can.