### PR TITLE
Correctly save hostname in build script

### DIFF
--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -69,7 +69,7 @@ sub save_system_info {
 	$nodename =~ s/\d+$//;
 	
 	# Save the hostname so the caller can use it
-	$args{'hostname'} = $nodename;
+	$args->{'hostname'} = $nodename;
 	
 	# Try to get the vendor name
 	my $vendor_name = 'unknown';


### PR DESCRIPTION
This fixes a bug introduced in #97.