### PR TITLE
export OMP_NUM_THREADS before invoking runTests in build script

### DIFF
--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -105,9 +105,9 @@ sub run {
 	eval {
 		execute(
 			"cd $base_dir\n" .
-			"export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n".
+			"export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n" .
+			"export OMP_NUM_THREADS=$args->{'nompthreads'}\n" .
 			"LD_LIBRARY_PATH=$paths:\$LD_LIBRARY_PATH " .
-			"OMP_NUM_THREADS=$args->{'nompthreads'} " .
 			"./runTests -all -log test.log -j$args->{'ntestjobs'} 1>stdout.log 2>stderr.log"
 		);
 	};


### PR DESCRIPTION
Fixes a bug from #102 