### PR TITLE
Fix test_relocations where it misses libc.so directory on aarch64

### DIFF
--- a/src/symtab/test_relocations.C
+++ b/src/symtab/test_relocations.C
@@ -78,6 +78,8 @@ class test_relocations_Mutator : public SymtabMutator {
            libc_dirs.push_back("/lib/x86_64-linux-gnu");
            // PowerpcLE 64-bit ubuntu
            libc_dirs.push_back("/lib/powerpc64le-linux-gnu");
+           // aarch64 ARM
+           libc_dirs.push_back("/lib/aarch64-linux-gnu");
            
            for (unsigned i = 0; i < libc_dirs.size(); ++i) {
               if (NULL == (dirp = opendir(libc_dirs[i].c_str()))) {


### PR DESCRIPTION
`test_relocations` was failing on `zeroah`. It turns out that the test itself cannot find libc.so on the system due to system specific path for libc.