### PR TITLE
proccontrol attach tests will hang if the tests are skipped.

### DIFF
--- a/src/dyninst/test_thread_2.C
+++ b/src/dyninst/test_thread_2.C
@@ -36,7 +36,6 @@
  * #Arch: all
  * #Notes:
  */
-
 #include <vector>
 using std::vector;
 #include "BPatch.h"
@@ -48,6 +47,7 @@ using std::vector;
 #include "test12.h"
 
 #include "dyninst_comp.h"
+
 class test_thread_2_Mutator : public DyninstMutator {
 private:
   BPatch *bpatch;
@@ -137,6 +137,12 @@ static void threadCreateCB(BPatch_process * proc, BPatch_thread *thr)
 
 // static bool mutatorTest3and4(int testno, const char *testname)
 test_results_t test_thread_2_Mutator::executeTest() {
+  BPatch_process *appProc = appThread->getProcess();
+  if (appProc && !appProc->supportsUserThreadEvents()) {
+    logerror("System does not support user thread events\n");
+    appThread->getProcess()->terminateExecution();
+    return SKIPPED;
+  }
   test3_threadCreateCounter = 0;
   callback_tids.clear();
 
@@ -169,7 +175,6 @@ test_results_t test_thread_2_Mutator::executeTest() {
 
   int err = 0;
   BPatch_Vector<BPatch_thread *> threads;
-  BPatch_process *appProc = appThread->getProcess();
   assert(appProc);
   appProc->getThreads(threads);
   int active_threads = 11; // FIXME Magic number

--- a/src/dyninst/test_thread_3.C
+++ b/src/dyninst/test_thread_3.C
@@ -137,6 +137,13 @@ static void threadCreateCB(BPatch_process * proc, BPatch_thread *thr)
 
 // static bool mutatorTest3and4(int testno, const char *testname)
 test_results_t test_thread_3_Mutator::executeTest() {
+  BPatch_process *appProc = appThread->getProcess();
+  if (appProc && !appProc->supportsUserThreadEvents()) {
+    logerror("System does not support user thread events\n");
+    appThread->getProcess()->terminateExecution();
+    return SKIPPED;
+  }
+
   test3_threadCreateCounter = 0;
   callback_tids.clear();
 
@@ -166,7 +173,6 @@ test_results_t test_thread_3_Mutator::executeTest() {
   //  (or timeout happens)
 
   BPatch_Vector<BPatch_thread *> threads;
-  BPatch_process *appProc = appThread->getProcess();
   assert(appProc);
   appProc->getThreads(threads);
   int active_threads = 11; // FIXME Magic number

--- a/src/dyninst/test_thread_5.C
+++ b/src/dyninst/test_thread_5.C
@@ -254,6 +254,13 @@ const char *threadLibName = "libpthread";
 
 // static int mutatorTest(BPatch_thread *appThread, BPatch_image *appImage)
 test_results_t test_thread_5_Mutator::executeTest() {
+  BPatch_process *appProc = appThread->getProcess();
+  if (appProc && !appProc->supportsUserThreadEvents()) {
+    logerror("System does not support user thread events\n");
+    appThread->getProcess()->terminateExecution();
+    return SKIPPED;
+  }
+
   test8done = false;
   test8err = false;
 

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -395,6 +395,12 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch)
 }
 
 test_results_t test_thread_6_Mutator::executeTest() {
+  BPatch_process *appProc = appThread->getProcess();
+  if (appProc && !appProc->supportsUserThreadEvents()) {
+    logerror("System does not support user thread events\n");
+    appThread->getProcess()->terminateExecution();
+    return SKIPPED;
+  }
 
    test_results_t rv = mutatorTest(bpatch);
 

--- a/src/proccontrol/proccontrol_comp.C
+++ b/src/proccontrol/proccontrol_comp.C
@@ -903,6 +903,23 @@ test_results_t ProcControlComponent::group_teardown(RunGroup *group, ParameterDi
       return PASSED;
    }
 
+   bool allSkippedTests = true;
+   for (unsigned j=0; j<group->tests.size(); j++) {
+       if (group->tests[j]->results[test_execute_rs] != SKIPPED) {
+           allSkippedTests = false;
+       }
+   }
+
+   if (allSkippedTests) {
+       // If all tests are skipped.
+       // Then the mutatee may be left in attached status forever.
+       // We can simply terminate the mutatees.
+       for (std::vector<Process::ptr>::iterator i = procs.begin(); i != procs.end(); i++) {
+           Process::ptr p = *i;
+           p->terminate();
+       }
+       return SKIPPED;
+   }
    Process::registerEventCallback(EventType(EventType::Post, EventType::Exit), default_on_exit);
    do {
       hasRunningProcs = false;


### PR DESCRIPTION
Fixes #110

This PR aims to fix the test suite hang when attach mode proccontrol tests are skipped. The test suite fails to terminate or continue the mutatees and hang. This PR terminates the mutatees since the tests are skipped.