### PR TITLE
Only run 64-bit tests when using build script

### DIFF
--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -152,7 +152,7 @@ sub run {
 				"export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n" .
 				"export OMP_NUM_THREADS=$args->{'nompthreads'}\n" .
 				"LD_LIBRARY_PATH=$paths:\$LD_LIBRARY_PATH " .
-				"./runTests -all -log test.log -j$args->{'ntestjobs'} 1>stdout.log 2>stderr.log"
+				"./runTests -64 -all -log test.log -j$args->{'ntestjobs'} 1>stdout.log 2>stderr.log"
 			);
 		};
 		$err = $@ if $@;


### PR DESCRIPTION
On platforms with 32-bit libraries installed, many tests are failing in 32-bit mode. We can't really deal with them right now, so we won't run them.