### PR TITLE
Fix incorrect behavior for switches without a value.

### DIFF
--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -15,6 +15,7 @@ my $invocation_args = join(' ',
 	map {
 		my ($l,$r)=split('=',$_,2);
 		$l .= "=\"$r\"" if $r;
+		$l;
 	} @ARGV
 );
 


### PR DESCRIPTION
When building the invocation argument string, account for the case when
there is no value passed to a switch.