### PR TITLE
Remove undefined behavior from runTests-utils.C:RunTest

### DIFF
--- a/src/runTests-utils.h
+++ b/src/runTests-utils.h
@@ -102,8 +102,8 @@ void initPIDFilename(char *buffer, size_t len);
 void cleanupMutatees(char *pidFilename);
 
 test_pid_t RunTest(unsigned int iteration, bool useLog, bool staticTests,
-                   std::string logfile, int testLimit, vector<char *> child_argv,
-                   const char *pidFilename, std::string hostname);
+                   std::string logfile, int testLimit, vector<char *> const& child_argv,
+                   const char *pidFilename, std::string const& hostname);
 
 int CollectTestResults(vector<test_driver_t> &test_drivers, int parallel_copies);
 


### PR DESCRIPTION
It is undefined behavior to refer to the pointer returned from `std::basic_string::c_str` after the owning string object's lifetime has expired.