### PR TITLE
Extend check after PR checkout before commiting in build script

### DIFF
--- a/scripts/build/Dyninst/git.pm
+++ b/scripts/build/Dyninst/git.pm
@@ -83,7 +83,7 @@ sub checkout_pr {
 				
 				# Running 'git commit' with nothing to commit returns a non-zero value.
 				# I think this is a bug in git, but just work around it for now.
-				if($stdout !~ /Already up-to-date/i) {
+				if($stdout !~ /Already up[- ]*to[- ]*date/i) {
 					execute(
 						"cd $src_dir \n" .
 						"git commit -m 'Merge $remote/master'"


### PR DESCRIPTION
Some git versions report 'Already up to date', while others report 'Already up-to-date'.