### PR TITLE
Fix fixed-width log parser in build script

### DIFF
--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -16,7 +16,7 @@ sub parse {
 		chomp;
 		
 		# Parse the fixed-width format
-		my @x = unpack('a27 a7 a5 a4 a9 a8 a8 a8 a23');
+		my @x = unpack('a27 a7 a5 a4 a9 a8 a8 a8 a50');
 
 		# Grab the status field (it's at the end)
 		my $status = pop @x;


### PR DESCRIPTION
The last field width was off-by-one when a crash occurred during group
teardown (i.e., result was 'CRASHED (Group Teardown)').