### PR TITLE
Don't skip rewriter tests for static pic mutatees

### DIFF
--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -118,9 +118,7 @@ sub run {
 			for my $link ('dynamiclink','staticlink') {
 			for my $mode ('create','attach','rewriter') {
 			for my $pic ('pic', 'nonpic') {
-				# Rewriting static PIC is broken on most architectures
-				next if $pic eq 'pic' && $link eq 'staticlink' && $mode eq 'rewriter';
-				
+
 				# This test is broken on Zeroah
 				next if $test_name eq 'test_thread_5' &&
 						$hostname =~ /zeroah/i &&


### PR DESCRIPTION
This fails on ARM because the implementation isn't complete, but it's good to start tracking these since work on this is undergoing again.