### PR TITLE
pcontrol_mutatee_tools.c: Comment out gettid()

### DIFF
--- a/src/proccontrol/pcontrol_mutatee_tools.c
+++ b/src/proccontrol/pcontrol_mutatee_tools.c
@@ -62,9 +62,9 @@
 #if !defined(os_windows_test)
 #include <poll.h>
 
-static unsigned int gettid(){
-    return (unsigned int)pthread_self();
-}
+//static unsigned int gettid(){
+//    return (unsigned int)pthread_self();
+//}
 #endif
 
 thread_t threads[MAX_POSSIBLE_THREADS];


### PR DESCRIPTION
The testsuite failed to build on x86_64 Fedora 31 with the error "ambiguating new declaration of 'unsigned int gettid()'". This may be due to glibc v2.30+ including its own gettid. Commenting out gettid fixes the problem since all calls to this function in pcontrol_mutatee_tools.c are already commented out.