### PR TITLE
Refactor how tests are run in build script

### DIFF
--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -179,7 +179,7 @@ sub new {
 	
 	bless {
 		'filename' => $filename,
-		'quiet'=> $quiet,
+		'quiet'=> $quiet // 1,
 		'fd' => $fdLog
 	}, $class;
 }

--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -10,11 +10,11 @@ use File::Copy qw(move);
 # ------------- Module methods -----------------------
 
 sub append_result {
-	my ($log_file, $test_name) = @_;
+	my ($log_file, $test_name, $result) = @_;
 	open my $fdOut, '>>', $log_file or die "$log_file: $!\n";
 	print $fdOut
 		pack('A27 A7 A5 A4 A9 A8 A8 A8 A50',
-			$test_name, '', '', '', '', '', '', 'HANGED', '');
+			$test_name, '', '', '', '', '', '', '', $result);
 }
 
 sub parse {

--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -32,7 +32,7 @@ sub parse {
 		# Grab the status field (it's at the end)
 		my $status = pop @x;
 		my $failed = 0;
-		for my $s ('FAILED','CRASHED') {
+		for my $s ('FAILED','CRASHED', 'HANGED') {
 			# Split the status from the reason
 			# The format is 'FAILED (reason)'
 			if ($status =~ /$s\s*\((.+)\)\s*$/) {

--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -14,7 +14,8 @@ sub append_result {
 	open my $fdOut, '>>', $log_file or die "$log_file: $!\n";
 	print $fdOut
 		pack('A27 A7 A5 A4 A9 A8 A8 A8 A50',
-			$test_name, '', '', '', '', '', '', '', $result);
+			$test_name, '', '', '', '', '', '', '', $result),
+		"\n";
 }
 
 sub parse {

--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -13,7 +13,7 @@ sub append_result {
 	my ($log_file, $test_name, $result) = @_;
 	open my $fdOut, '>>', $log_file or die "$log_file: $!\n";
 	print $fdOut
-		pack('A27 A7 A5 A4 A9 A8 A8 A8 A50',
+		pack('A27 A7 A5 A4 A9 A8 A8 A8 A' . length($result),
 			$test_name, '', '', '', '', '', '', '', $result),
 		"\n";
 }
@@ -33,7 +33,7 @@ sub parse {
 		# Grab the status field (it's at the end)
 		my $status = pop @x;
 		my $failed = 0;
-		for my $s ('FAILED','CRASHED', 'HANGED') {
+		for my $s ('FAILED','CRASHED') {
 			# Split the status from the reason
 			# The format is 'FAILED (reason)'
 			if ($status =~ /$s\s*\((.+)\)\s*$/) {

--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -9,6 +9,14 @@ use File::Copy qw(move);
 
 # ------------- Module methods -----------------------
 
+sub append_result {
+	my ($log_file, $test_name) = @_;
+	open my $fdOut, '>>', $log_file or die "$log_file: $!\n";
+	print $fdOut
+		pack('A27 A7 A5 A4 A9 A8 A8 A8 A50',
+			$test_name, '', '', '', '', '', '', 'HANGED', '');
+}
+
 sub parse {
 	open my $fdIn, '<', $_[0] or die "$_[0]: $!\n";
 	my @results;

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -98,7 +98,7 @@ sub _killed_by_watchdog {
 }
 
 sub _run_single {
-	my ($paths, $args, $base_dir, $build_log) = @_;
+	my ($paths, $args, $base_dir, $run_log) = @_;
 	
 	my $test_names_file = "$base_dir/../build/test_names.txt";
 	open my $fdTests, '<', $test_names_file or die "Unable to open '$test_names_file': $!\n";
@@ -130,11 +130,11 @@ sub _run_single {
 		my $end = Time::HiRes::gettimeofday();
 		
 		if($Dyninst::utils::debug_mode) {
-			$build_log->write(sprintf("$test_name took %.2f seconds", $end - $start));
+			$run_log->write(sprintf("$test_name took %.2f seconds", $end - $start));
 		}
 		
 		if(_killed_by_watchdog("$base_dir/stderr.tmp")) {
-			$build_log->write("$test_name exceeded time limit");
+			$run_log->write("$test_name exceeded time limit");
 		}
 		
 		# Concatenate the temporary logs with the permanent ones
@@ -149,7 +149,7 @@ sub _run_single {
 }
 
 sub run {
-	my ($args, $base_dir, $build_log) = @_;
+	my ($args, $base_dir, $run_log) = @_;
 
 	# Grab the paths in the Dyninst build cache
 	my @lib_dirs = (
@@ -169,7 +169,7 @@ sub run {
 	
 	# If user explicitly requests single-stepping, then only run that mode
 	if($args->{'single-stepping'}) {
-		_run_single($paths, $args, $base_dir, $build_log);
+		_run_single($paths, $args, $base_dir, $run_log);
 		return;
 	}
 
@@ -188,8 +188,8 @@ sub run {
 		# check it here explicitly just to be sure
 		die if _killed_by_watchdog("$base_dir/stderr.log");
 	} catch {
-		$build_log->write("Running in group mode failed. Running single-step mode.\n");
-		_run_single($paths, $args, $base_dir, $build_log);
+		$run_log->write("Running in group mode failed. Running single-step mode.\n");
+		_run_single($paths, $args, $base_dir, $run_log);
 	};
 }
 

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -128,7 +128,10 @@ sub _run_single {
 		};
 		
 		my $end = Time::HiRes::gettimeofday();
-		$build_log->write(sprintf("Running $test_name took %.2f seconds", $end - $start));
+		
+		if($Dyninst::utils::debug_mode) {
+			$build_log->write(sprintf("$test_name took %.2f seconds", $end - $start));
+		}
 		
 		if(_killed_by_watchdog("$base_dir/stderr.tmp")) {
 			$build_log->write("$test_name exceeded time limit");

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -170,7 +170,7 @@ sub run {
 	# If user explicitly requests single-stepping, then only run that mode
 	if($args->{'single-stepping'}) {
 		_run_single($paths, $args, $base_dir, $build_log);
-		return;		
+		return;
 	}
 
 	# By default, run the tests in group mode

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -127,9 +127,8 @@ sub _run_single {
 			print $fdErr "\n$test_name failed in testsuite::run", '-'x10, "\n";
 		};
 		
-		my $end = Time::HiRes::gettimeofday();
-		
 		if($Dyninst::utils::debug_mode) {
+			my $end = Time::HiRes::gettimeofday();
 			$run_log->write(sprintf("$test_name took %.2f seconds", $end - $start));
 		}
 		

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -134,7 +134,7 @@ sub _run_single {
 		
 		if(_killed_by_watchdog("$base_dir/stderr.tmp")) {
 			$run_log->write("$test_name exceeded time limit");
-			Dyninst::logs::append_result("$base_dir/stdout.tmp", $test_name);
+			Dyninst::logs::append_result("$base_dir/stdout.tmp", $test_name, 'HANGED');
 		}
 		
 		# Concatenate the temporary logs with the permanent ones

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -9,6 +9,7 @@ use Dyninst::logs;
 use Cwd qw(realpath);
 use File::Path qw(make_path);
 use Time::HiRes;
+use Try::Tiny;
 
 sub setup {
 	my ($root_dir, $args) = @_;
@@ -82,8 +83,70 @@ sub build {
 	};
 	die "Error installing: see $build_dir/build-install.err for details" if $@;
 }
+
+sub _killed_by_watchdog {
+	my ($file) = @_;
+	
+	# Check if we were killed by the watchdog timer
+	if(-f $file){
+		open my $fdIn, '<', $file;
+		while(<$fdIn>) {
+			return 1 if m/Process exceeded time limit/;
+		}
+	}
+	return 0;
+}
+
+sub _run_single {
+	my ($paths, $args, $base_dir, $build_log) = @_;
+	
+	my $test_names_file = "$base_dir/../build/test_names.txt";
+	open my $fdTests, '<', $test_names_file or die "Unable to open '$test_names_file': $!\n";
+	open my $fdLog, '>', "$base_dir/test.log" or die "Unable to open '$base_dir/test.log': $!\n";
+
+	open my $fdOut, '>', "$base_dir/stdout.log";
+	open my $fdErr, '>', "$base_dir/stderr.log";
+
+	while(my $test_name = <$fdTests>) {
+		chomp($test_name);
+
+		# Put a marker in the stderr log
+		print $fdErr "++Running $test_name\n";
+		
+		my $start = Time::HiRes::gettimeofday();
+		
+		try {
+			execute(
+				"cd $base_dir\n" .
+				"export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n" .
+				"export OMP_NUM_THREADS=$args->{'nompthreads'}\n" .
+				"LD_LIBRARY_PATH=$paths:\$LD_LIBRARY_PATH " .
+				"./runTests -64 -all -test $test_name -log tmp.log 1>stdout.tmp 2>stderr.tmp"
+			);
+		} catch {
+			print $fdErr "\n$test_name failed in testsuite::run", '-'x10, "\n";
+		};
+		
+		my $end = Time::HiRes::gettimeofday();
+		$build_log->write(sprintf("Running $test_name took %.2f seconds", $end - $start));
+		
+		if(_killed_by_watchdog("$base_dir/stderr.tmp")) {
+			$build_log->write("$test_name exceeded time limit");
+		}
+		
+		# Concatenate the temporary logs with the permanent ones
+		for my $f (['stdout.tmp',$fdOut],['stderr.tmp',$fdErr],['tmp.log',$fdLog]) {
+			if(-f "$base_dir/$f->[0]") {
+				open my $fdIn, '<', "$base_dir/$f->[0]";
+				my $x = $f->[1];
+				print $x (<$fdIn>);
+			}
+		}
+	}
+}
+
 sub run {
-	my ($args, $base_dir) = @_;
+	my ($args, $base_dir, $build_log) = @_;
 
 	# Grab the paths in the Dyninst build cache
 	my @lib_dirs = (
@@ -100,83 +163,31 @@ sub run {
 	
 	push @libs, ($base_dir, realpath("$base_dir/../dyninst/lib"));
 	my $paths = join(':', list_unique(@libs));
-
+	
+	# If user explicitly requests single-stepping, then only run that mode
 	if($args->{'single-stepping'}) {
-		my $test_names_file = "$base_dir/../build/test_names.txt";
-		open my $fdTests, '<', $test_names_file or die "Unable to open '$test_names_file': $!\n";
-		open my $fdLog, '>', "$base_dir/test.log" or die "Unable to open '$base_dir/test.log': $!\n";
-		
-		open my $fdOut, '>', "$base_dir/stdout.log";
-		open my $fdErr, '>', "$base_dir/stderr.log";
-		
-		my $hostname = Dyninst::logs::get_system_info()->{'nodename'};
-		
-		while(my $test_name = <$fdTests>) {
-			chomp($test_name);
-	
-            # This test is broken on Zeroah
-            next if $test_name eq 'test_thread_5' &&
-                    $hostname =~ /zeroah/i;
-            
-            print "Running $test_name";
-            my $start = Time::HiRes::gettimeofday();
-            
-            # We need an 'eval' here since we are manually piping stderr
-            eval {
-                execute(
-                    "cd $base_dir\n" .
-                    "export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n" .
-                    "export OMP_NUM_THREADS=$args->{'nompthreads'}\n" .
-                    "LD_LIBRARY_PATH=$paths:\$LD_LIBRARY_PATH " .
-                    "./runTests -64 -all -test $test_name -log tmp.log 1>stdout.tmp 2>stderr.tmp"
-                );
-            };
-            my $end = Time::HiRes::gettimeofday();
-            printf("%.2f\n", $end - $start);
-            
-            for my $f (['stdout.tmp',$fdOut],['stderr.tmp',$fdErr],['tmp.log',$fdLog]) {
-                if(-f "$base_dir/$f->[0]") {
-                    open my $fdIn, '<', "$base_dir/$f->[0]";
-                    my $x = $f->[1];
-                    print $x (<$fdIn>);
-                }
-            }
-		}
-	} else {
-		my $err = undef;
-		# We need an 'eval' here since we are manually piping stderr
-		eval {
-			execute(
-				"cd $base_dir\n" .
-				"export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n" .
-				"export OMP_NUM_THREADS=$args->{'nompthreads'}\n" .
-				"LD_LIBRARY_PATH=$paths:\$LD_LIBRARY_PATH " .
-				"./runTests -64 -all -log test.log -j$args->{'ntestjobs'} 1>stdout.log 2>stderr.log"
-			);
-		};
-		$err = $@ if $@;
-	
-		# Check if we were killed by the watchdog timer
-		open my $fdIn, '<', "$base_dir/stderr.log";
-		while(<$fdIn>) {
-			return !!0 if m/Process exceeded time limit/;
-		}
-	
-		# The run failed for some reason other than the watchdog timer
-		chomp($err);
-		if($err && $err eq '') {
-			# runTest returned a non-zero value, but no actual error
-			# message. Check the log for an error message
-			open my $fdIn, '<', "$base_dir/stderr.log" or die "$!\n";
-			while(<$fdIn>) {
-				if(/\berror\b/i) {
-					die "\nrunTests terminated abnormally\n\n\n$err\n";
-				}
-			}
-		}
+		_run_single($paths, $args, $base_dir, $build_log);
+		return;		
 	}
-	
-	return !!1;
+
+	# By default, run the tests in group mode
+	# If that fails, fall back to single-stepping mode
+	try {
+		execute(
+			"cd $base_dir\n" .
+			"export DYNINSTAPI_RT_LIB=$base_dir/../dyninst/lib/libdyninstAPI_RT.so\n" .
+			"export OMP_NUM_THREADS=$args->{'nompthreads'}\n" .
+			"LD_LIBRARY_PATH=$paths:\$LD_LIBRARY_PATH " .
+			"./runTests -64 -all -log test.log 1>stdout.log 2>stderr.log"
+		);
+		
+		# Being killed by the watchdog timer _should_ cause 'execute' to throw, but
+		# check it here explicitly just to be sure
+		die if _killed_by_watchdog("$base_dir/stderr.log");
+	} catch {
+		$build_log->write("Running in group mode failed. Running single-step mode.\n");
+		_run_single($paths, $args, $base_dir, $build_log);
+	};
 }
 
 1;

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -134,6 +134,7 @@ sub _run_single {
 		
 		if(_killed_by_watchdog("$base_dir/stderr.tmp")) {
 			$run_log->write("$test_name exceeded time limit");
+			Dyninst::logs::append_result("$base_dir/stdout.tmp", $test_name);
 		}
 		
 		# Concatenate the temporary logs with the permanent ones

--- a/scripts/build/Try/Tiny.pm
+++ b/scripts/build/Try/Tiny.pm
@@ -1,0 +1,210 @@
+package Try::Tiny; # git description: v0.29-2-g3b23a06
+use 5.006;
+# ABSTRACT: Minimal try/catch with proper preservation of $@
+
+our $VERSION = '0.30';
+
+use strict;
+use warnings;
+
+use Exporter 5.57 'import';
+our @EXPORT = our @EXPORT_OK = qw(try catch finally);
+
+use Carp;
+$Carp::Internal{+__PACKAGE__}++;
+
+BEGIN {
+  my $su = $INC{'Sub/Util.pm'} && defined &Sub::Util::set_subname;
+  my $sn = $INC{'Sub/Name.pm'} && eval { Sub::Name->VERSION(0.08) };
+  unless ($su || $sn) {
+    $su = eval { require Sub::Util; } && defined &Sub::Util::set_subname;
+    unless ($su) {
+      $sn = eval { require Sub::Name; Sub::Name->VERSION(0.08) };
+    }
+  }
+
+  *_subname = $su ? \&Sub::Util::set_subname
+            : $sn ? \&Sub::Name::subname
+            : sub { $_[1] };
+  *_HAS_SUBNAME = ($su || $sn) ? sub(){1} : sub(){0};
+}
+
+my %_finally_guards;
+
+# Need to prototype as @ not $$ because of the way Perl evaluates the prototype.
+# Keeping it at $$ means you only ever get 1 sub because we need to eval in a list
+# context & not a scalar one
+
+sub try (&;@) {
+  my ( $try, @code_refs ) = @_;
+
+  # we need to save this here, the eval block will be in scalar context due
+  # to $failed
+  my $wantarray = wantarray;
+
+  # work around perl bug by explicitly initializing these, due to the likelyhood
+  # this will be used in global destruction (perl rt#119311)
+  my ( $catch, @finally ) = ();
+
+  # find labeled blocks in the argument list.
+  # catch and finally tag the blocks by blessing a scalar reference to them.
+  foreach my $code_ref (@code_refs) {
+
+    if ( ref($code_ref) eq 'Try::Tiny::Catch' ) {
+      croak 'A try() may not be followed by multiple catch() blocks'
+        if $catch;
+      $catch = ${$code_ref};
+    } elsif ( ref($code_ref) eq 'Try::Tiny::Finally' ) {
+      push @finally, ${$code_ref};
+    } else {
+      croak(
+        'try() encountered an unexpected argument ('
+      . ( defined $code_ref ? $code_ref : 'undef' )
+      . ') - perhaps a missing semi-colon before or'
+      );
+    }
+  }
+
+  # FIXME consider using local $SIG{__DIE__} to accumulate all errors. It's
+  # not perfect, but we could provide a list of additional errors for
+  # $catch->();
+
+  # name the blocks if we have Sub::Name installed
+  _subname(caller().'::try {...} ' => $try)
+    if _HAS_SUBNAME;
+
+  # set up scope guards to invoke the finally blocks at the end.
+  # this should really be a function scope lexical variable instead of
+  # file scope + local but that causes issues with perls < 5.20 due to
+  # perl rt#119311
+  local $_finally_guards{guards} = [
+    map { Try::Tiny::ScopeGuard->_new($_) }
+    @finally
+  ];
+
+  # save the value of $@ so we can set $@ back to it in the beginning of the eval
+  # and restore $@ after the eval finishes
+  my $prev_error = $@;
+
+  my ( @ret, $error );
+
+  # failed will be true if the eval dies, because 1 will not be returned
+  # from the eval body
+  my $failed = not eval {
+    $@ = $prev_error;
+
+    # evaluate the try block in the correct context
+    if ( $wantarray ) {
+      @ret = $try->();
+    } elsif ( defined $wantarray ) {
+      $ret[0] = $try->();
+    } else {
+      $try->();
+    };
+
+    return 1; # properly set $failed to false
+  };
+
+  # preserve the current error and reset the original value of $@
+  $error = $@;
+  $@ = $prev_error;
+
+  # at this point $failed contains a true value if the eval died, even if some
+  # destructor overwrote $@ as the eval was unwinding.
+  if ( $failed ) {
+    # pass $error to the finally blocks
+    push @$_, $error for @{$_finally_guards{guards}};
+
+    # if we got an error, invoke the catch block.
+    if ( $catch ) {
+      # This works like given($error), but is backwards compatible and
+      # sets $_ in the dynamic scope for the body of C<$catch>
+      for ($error) {
+        return $catch->($error);
+      }
+
+      # in case when() was used without an explicit return, the C<for>
+      # loop will be aborted and there's no useful return value
+    }
+
+    return;
+  } else {
+    # no failure, $@ is back to what it was, everything is fine
+    return $wantarray ? @ret : $ret[0];
+  }
+}
+
+sub catch (&;@) {
+  my ( $block, @rest ) = @_;
+
+  croak 'Useless bare catch()' unless wantarray;
+
+  _subname(caller().'::catch {...} ' => $block)
+    if _HAS_SUBNAME;
+  return (
+    bless(\$block, 'Try::Tiny::Catch'),
+    @rest,
+  );
+}
+
+sub finally (&;@) {
+  my ( $block, @rest ) = @_;
+
+  croak 'Useless bare finally()' unless wantarray;
+
+  _subname(caller().'::finally {...} ' => $block)
+    if _HAS_SUBNAME;
+  return (
+    bless(\$block, 'Try::Tiny::Finally'),
+    @rest,
+  );
+}
+
+{
+  package # hide from PAUSE
+    Try::Tiny::ScopeGuard;
+
+  use constant UNSTABLE_DOLLARAT => ("$]" < '5.013002') ? 1 : 0;
+
+  sub _new {
+    shift;
+    bless [ @_ ];
+  }
+
+  sub DESTROY {
+    my ($code, @args) = @{ $_[0] };
+
+    local $@ if UNSTABLE_DOLLARAT;
+    eval {
+      $code->(@args);
+      1;
+    } or do {
+      warn
+        "Execution of finally() block $code resulted in an exception, which "
+      . '*CAN NOT BE PROPAGATED* due to fundamental limitations of Perl. '
+      . 'Your program will continue as if this event never took place. '
+      . "Original exception text follows:\n\n"
+      . (defined $@ ? $@ : '$@ left undefined...')
+      . "\n"
+      ;
+    }
+  }
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is Copyright (c) 2009 by ×™×•×‘×œ ×§×•×’'×ž×Ÿ (Yuval Kogman).
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
+=cut

--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -200,7 +200,7 @@ if($args{'run-tests'}) {
 	make_path("$root_dir/testsuite/tests");
 	my $base_dir = realpath("$root_dir/testsuite/tests");
 	
-	my $run_log = Dyninst::logs->new("$base_dir/testsuite/tests/run.log");
+	my $run_log = Dyninst::logs->new("$base_dir/run.log");
 
 	$logger->write("running Testsuite... ", 'eol'=>'');
 	Dyninst::testsuite::run(\%args, $base_dir, $run_log);

--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -199,9 +199,11 @@ if($@) {
 if($args{'run-tests'}) {
 	make_path("$root_dir/testsuite/tests");
 	my $base_dir = realpath("$root_dir/testsuite/tests");
+	
+	my $run_log = Dyninst::logs->new("$base_dir/testsuite/tests/run.log");
 
 	$logger->write("running Testsuite... ", 'eol'=>'');
-	Dyninst::testsuite::run(\%args, $base_dir, $logger);
+	Dyninst::testsuite::run(\%args, $base_dir, $run_log);
 	$logger->write("done.");
 }
 
@@ -239,6 +241,7 @@ if(-f "$root_dir/testsuite/tests/stdout.log") {
 		"$root_dir/testsuite/tests/stdout.log",
 		"$root_dir/testsuite/tests/stderr.log",
 		"$root_dir/testsuite/tests/test.log",
+		"$root_dir/testsuite/tests/run.log",
 		$results_log
 	);
 


### PR DESCRIPTION
1. Running in single-stepping mode captures hangs
2. If 'runTest -all' hangs, it will be re-run in single-stepping mode
3. Improve logging to better trace where errors are happening
4. Remove platform-dependent run configs