### PR TITLE
Reduce watchdog timeout to ten minutes

### DIFF
--- a/src/runTests-utils.C
+++ b/src/runTests-utils.C
@@ -45,7 +45,7 @@
 
 extern string pdscrdir;
 
-int timeout = 1200; /* seconds */
+int timeout = 600; /* seconds */
 
 void initPIDFilename(char *buffer, size_t len) {
   snprintf(buffer, len, "pids.%d", getpid());


### PR DESCRIPTION
In my testing, I've found that even the slowest machine will only take 4-6 minutes maximum to execute any given group of tests. Waiting twenty minutes for a hang leads to longer run times than is necessary.