### PR TITLE
Make test suite buildable with Clang

### DIFF
--- a/src/dyninst/test1_3.C
+++ b/src/dyninst/test1_3.C
@@ -134,7 +134,7 @@ test_results_t test1_3_Mutator::executeTest()
 	}
 
 	// see if we can find the address
-	if (expr3_1->getBaseAddr() <= 0) 
+	if (!expr3_1->getBaseAddr())
 	{
 		logerror("*Error*: address %p for %s is not valid\n",
 				expr3_1->getBaseAddr(), globalVar);


### PR DESCRIPTION
Fix pointer comparison for clang build. gcc warns about this, but clang treats it as an error.

See also https://github.com/dyninst/dyninst/pull/705