### PR TITLE
build script: Allow user to override the hostname

### DIFF
--- a/scripts/build/Dyninst/logs.pm
+++ b/scripts/build/Dyninst/logs.pm
@@ -111,9 +111,14 @@ sub get_system_info {
 }
 
 sub save_system_info {
-	my ($logger) = @_;
+	my ($logger, $hostname) = @_;
 	
 	my $sysinfo = get_system_info();
+	
+	# Allow user to override the hostname
+	if(defined $hostname) {
+		$sysinfo->{'nodename'} = $hostname;
+	}
 	
 	$logger->write(
 		"os: $sysinfo->{'sysname'}\n" .

--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -314,5 +314,6 @@ build [options]
    --single-stepping       Run the tests one at a time (i.e., not in 'group' mode) (default: no)
    --auth-token=STRING     The authentication token string. Required when uploading the results.
    --[no-]sterile          Use a sterile build- don't download dependencies (default: yes)
+   --hostname              Override the hostname provided by `uname`
    --help                  Print this help message
 =cut

--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -44,6 +44,7 @@ my %args = (
 	'single-stepping'		=> 0,
 	'auth-token'			=> undef,
 	'sterile'				=> 1,
+	'hostname'				=> undef,
 	'debug-mode'			=> 0	# undocumented debug mode
 );
 
@@ -55,7 +56,7 @@ GetOptions(\%args,
 	'run-tests!', 'tests!', 'njobs=i', 'quiet', 'purge',
 	'help', 'restart=s', 'upload!', 'ntestjobs=i',
 	'nompthreads=i', 'single-stepping', 'auth-token=s',
-	'sterile!', 'debug-mode'
+	'sterile!', 'hostname=s', 'debug-mode'
 ) or pod2usage(-exitval=>2);
 
 if($args{'help'}) {
@@ -139,7 +140,7 @@ if($Dyninst::utils::debug_mode) {
 	print Dumper(\%args), "\n";
 }
 
-Dyninst::logs::save_system_info($logger);
+Dyninst::logs::save_system_info($logger, $args{'hostname'});
 
 # Generate a unique name for the current build
 $root_dir = tempdir('XXXXXXXX', CLEANUP=>0) unless $args{'restart'};


### PR DESCRIPTION
This is useful when the default hostname isn't related to the name of
the HPC machine (e.g., compute notes at cori.nersc.gov are named 'nid').