### PR TITLE
Add -dry-run and -exclude

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -62,6 +62,8 @@ static void print_help()
    fprintf(stderr, "Tests\n");
    fprintf(stderr, "  -test <test>,<test>,...           specifies test mutators to run.\n");
    fprintf(stderr, "                                    Wildcards are valid in the test name.\n");
+   fprintf(stderr, "  -exclude <test>,<test>,...        specifies test mutators to not run.\n");
+   fprintf(stderr, "                                    Wildcards are valid in the test name.\n");
    fprintf(stderr, "  -mutatee <mutatee>,<mutatee>,...  specifies test mutatees to run\n");
    fprintf(stderr, "                                    Wildcards are valid in the mutatee name.\n");
    fprintf(stderr, "\n");
@@ -125,6 +127,9 @@ static void print_help()
    fprintf(stderr, "                                    is suitable for submission to a database.\n");
    fprintf(stderr, "  -memcpu                           Gather memory usage and cpu elapsed time\n");
    fprintf(stderr, "                                    information for each test.\n");
+   fprintf(stderr, "  -dry-run                          Print the tests that would be run without\n");
+   fprintf(stderr, "                                    actually running them. Use the -v option\n");
+   fprintf(stderr, "                                    to display additional info.\n");
    fprintf(stderr, "\n");
    fprintf(stderr, "Running Tests in Parallel\n");
    fprintf(stderr, "-------------------------\n");


### PR DESCRIPTION
Add -exclude as a complement to -test and -dry-run to list the tests that would be run.

-exclude allows excluding tests, e.g. if a test is looping due to a bug but one would like to easily run the remainder of the testsuite.  -dry-run gives a convenient way to see which tests would be run: 1) the info is packed a bit tighter than typical test results to allow more info to be displayed with -v 2)  output simply uses printf, it could use StdOutputDriver but that seemed overkill.