### PR TITLE
Fix data race in test_thread_6

### DIFF
--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -38,9 +38,6 @@
 #include <cstdio>
 #include <unordered_map>
 
-#include <pthread.h>
-#include <sys/types.h>
-
 class test_thread_6_Mutator : public DyninstMutator {
 protected:
   BPatch *bpatch;
@@ -117,9 +114,7 @@ bool has_value(Container const &c, std::mutex &m, Value v) {
 
 static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
   dprintf("%s[%d]:  welcome to deadthr\n", __FILE__, __LINE__);
-  dprintf("deadthr: pthread tid is %u\n", pthread_self());
-  dprintf("deadthr: linux tid is %d\n", gettid());
-  dprintf("In newthr, appProc=%x\n", my_proc);
+
   if (!thr) {
     dprintf("%s[%d]:  deadthr called without valid ptr to thr\n", __FILE__,
             __LINE__);
@@ -145,9 +140,6 @@ static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
 static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
   dprintf("%s[%d]:  welcome to newthr, error13 = %d\n", __FILE__, __LINE__,
           error13.load());
-  dprintf("newthr: pthread tid is %u\n", pthread_self());
-  dprintf("newthr: linux tid is %d\n", gettid());
-  dprintf("In newthr, appProc=%x\n", my_proc);
 
   if (my_proc != mutatee_process) {
     dprintf("[%s:%u] - Got invalid process: %p vs %p\n", __FILE__, __LINE__,
@@ -392,11 +384,6 @@ test_results_t test_thread_6_Mutator::executeTest() {
   error13.store(0U);
   clear(tids, tids_mtx);
 
-  dprintf("In executeTest, this->appProc=%x, appProc=%x, mutatee_process=%x\n",
-		  this->appProc, appProc, mutatee_process);
-  dprintf("executeTest: pthread tid is %u\n", pthread_self());
-  dprintf("executeTest: linux tid is %d\n", gettid());
-
   test_results_t rv = mutatorTest(bpatch);
 
   if (!bpatch->removeThreadEventCallback(BPatch_threadCreateEvent, newthr) ||
@@ -426,10 +413,6 @@ test_results_t test_thread_6_Mutator::setup(ParameterDict &param) {
   appProc = (BPatch_process *)(param["appProcess"]->getPtr());
   if (appProc)
     appImage = appProc->getImage();
-
-  dprintf("In setup, appProc = %x\n", appProc);
-  dprintf("setup: pthread tid is %u\n", pthread_self());
-  dprintf("setup: linux tid is %d\n", gettid());
 
   return DyninstMutator::setup(param);
 }

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -194,9 +194,14 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
       "init_func",         "main",          "_start", "__start",
       "__libc_start_main", "mainCRTStartup"};
 
+  // clang-format off
   const bool found_name =
-      std::find(std::begin(initial_funcs), std::end(initial_funcs), name) !=
-      std::end(initial_funcs);
+      std::find_if(
+        std::begin(initial_funcs),
+		std::end(initial_funcs),
+        [&name](char const *n) { return strcmp(name, n) == 0; }
+      ) != std::end(initial_funcs);
+  // clang-format on
 
   // Initial thread function detection is proving VERY difficult on Windows,
   // currently leaving disabled.

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -76,7 +76,7 @@ namespace {
 
 template <typename... Args> static void dprintf(char const *fmt, Args... args) {
   if (debug_flag) {
-	std::lock_guard<std::mutex> l{print_mtx};
+    std::lock_guard<std::mutex> l{print_mtx};
     fprintf(stdout, fmt, args...);
     fflush(stdout);
   }
@@ -97,20 +97,19 @@ void insert(Container &c, std::mutex &m, Key k, Value v) {
   std::lock_guard<std::mutex> l{m};
   c[k] = v;
 }
-template <typename Container>
-void clear(Container &c, std::mutex &m) {
+template <typename Container> void clear(Container &c, std::mutex &m) {
   std::lock_guard<std::mutex> l{m};
   c.clear();
 }
 template <typename Container, typename Value>
-bool has_value(Container const& c, std::mutex &m, Value v) {
-	std::lock_guard<std::mutex> l{m};
-	for(auto const& p : tids) {
-		if(p.second == v) {
-			return true;
-		}
-	}
-	return false;
+bool has_value(Container const &c, std::mutex &m, Value v) {
+  std::lock_guard<std::mutex> l{m};
+  for (auto const &p : tids) {
+    if (p.second == v) {
+      return true;
+    }
+  }
+  return false;
 }
 
 static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
@@ -170,11 +169,11 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
     return;
   }
 
-  if(has_value(tids, tids_mtx, mytid)) {
-  	dprintf("[%s:%d] - WARNING: Thread %u has a duplicate tid (%d)\n",
-  			__FILE__, __LINE__, thr_bp_id, static_cast<int>(mytid));
-  	error13.store(1);
-  	return;
+  if (has_value(tids, tids_mtx, mytid)) {
+    dprintf("[%s:%d] - WARNING: Thread %u has a duplicate tid (%d)\n", __FILE__,
+            __LINE__, thr_bp_id, static_cast<int>(mytid));
+    error13.store(1);
+    return;
   }
 
   insert(tids, tids_mtx, thr_bp_id, mytid);
@@ -311,7 +310,8 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   num_attempts = 0;
   while (num_attempts != TIMEOUT) {
     const auto cnt = deleted_threads.load();
-    if(cnt == NUM_THREADS) break;
+    if (cnt == NUM_THREADS)
+      break;
     num_attempts++;
     dprintf("%s[%d]: Deleted %d and expected %d\n", __FILE__, __LINE__, cnt,
             NUM_THREADS);
@@ -319,11 +319,12 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   }
 
   {
-	  std::lock_guard<std::mutex> l{tids_mtx};
-	  for(auto const& p : tids) {
-		  dprintf("Thread %u:%d wasn't deleted\n", p.first, static_cast<int>(p.second));
-		  error13.store(1);
-	  }
+    std::lock_guard<std::mutex> l{tids_mtx};
+    for (auto const &p : tids) {
+      dprintf("Thread %u:%d wasn't deleted\n", p.first,
+              static_cast<int>(p.second));
+      error13.store(1);
+    }
   }
 
   if (deleted_threads.load() != NUM_THREADS) {

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -261,12 +261,6 @@ void test_thread_6_Mutator::upgrade_mutatee_state()
    dprintf("%s[%d]:  upgrade_mutatee_state: continued after write, val = %d\n", __FILE__, __LINE__, val);
 }
 
-#define MAX_ARGS 32
-static const char *filename = "test13.mutatee_gcc";
-static const char *args[MAX_ARGS];
-static const char *create_arg = "-create";
-static unsigned num_args = 0; 
-
 // This method creates (or attaches to?) the mutatee process and returns a
 // handle for it
 BPatch_process *test_thread_6_Mutator::getProcess()
@@ -423,7 +417,6 @@ test_results_t test_thread_6_Mutator::executeTest() {
 test_results_t test_thread_6_Mutator::setup(ParameterDict &param) {
    /* Grab info from param */
    bpatch = (BPatch *)(param["bpatch"]->getPtr());
-   filename = param["pathname"]->getString();
    logfilename = param["logfilename"]->getString();
    
    thread_count.store(0U);

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -173,42 +173,6 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
 
   insert(tids, tids_mtx, thr_bp_id, mytid);
   thread_count++;
-
-  char name[24];
-  BPatch_function *f = thr->getInitialFunc();
-  if (f)
-    f->getName(name, sizeof(name));
-  else
-    strcpy(name, "<NONE>");
-
-  dprintf("%s[%d]:  newthr initial function name: %s\n", __FILE__, __LINE__,
-          name);
-
-  char const *initial_funcs[] = {
-      "init_func",         "main",          "_start", "__start",
-      "__libc_start_main", "mainCRTStartup"};
-
-  // clang-format off
-  const bool found_name =
-      std::find_if(
-        std::begin(initial_funcs),
-		std::end(initial_funcs),
-        [&name](char const *n) { return strcmp(name, n) == 0; }
-      ) != std::end(initial_funcs);
-  // clang-format on
-
-  if (!found_name) {
-    // We can get unexpected threads with different initial functions; do not
-    // include them (but don't consider it an error). If we don't walk the
-    // stack right, then we won't have enough expected threads and so check
-    // it later.
-    dprintf(
-        "[%s:%d] - Thread %u has unexpected initial function '%s'; ignoring\n",
-        __FILE__, __LINE__, thr_bp_id, name);
-  }
-
-  dprintf("%s[%d]:  leaving newthr: error13 = %d\n", __FILE__, __LINE__,
-          error13.load());
 }
 
 void test_thread_6_Mutator::upgrade_mutatee_state() {

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -268,15 +268,19 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
     mutatee_process->continueExecution();
     bpatch->waitForStatusChange();
   }
-  num_attempts = 0;
-  while (num_attempts != TIMEOUT) {
-    const auto cnt = deleted_threads.load();
-    if (cnt == NUM_THREADS)
-      break;
-    num_attempts++;
-    dprintf("%s[%d]: Deleted %d and expected %d\n", __FILE__, __LINE__, cnt,
-            NUM_THREADS);
-    P_sleep(1);
+
+  {
+	auto num_attempts = 0;
+	do {
+		const auto cnt = deleted_threads.load();
+		if (cnt == NUM_THREADS) break;
+		if(++num_attempts >= TIMEOUT) {
+			dprintf("Detecting deleted threads timed out: Got %u, but expected %d\n", cnt, NUM_THREADS);
+			error13.store(1);
+			break;
+		}
+		P_sleep(1);
+	} while(1);
   }
 
   {

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -359,9 +359,8 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch)
    num_attempts = 0;
    while(deleted_threads != NUM_THREADS && num_attempts != TIMEOUT) {
       num_attempts++;
-	  std::cerr << "Deleted " << deleted_threads << " and expected " << NUM_THREADS << std::endl;
+	  dprintf("%s[%d]: Deleted %d and expected %d\n", __FILE__, __LINE__, deleted_threads, NUM_THREADS);
 	  P_sleep(1);
-
    }
 
    for (unsigned i=1; i<NUM_THREADS; i++)

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -39,26 +39,19 @@
 
 class test_thread_6_Mutator : public DyninstMutator {
 protected:
-  char *logfilename;
   BPatch *bpatch;
-  bool create_proc;
 
   void upgrade_mutatee_state();
   BPatch_process *getProcess();
   test_results_t mutatorTest(BPatch *bpatch);
 
 public:
-  test_thread_6_Mutator();
-  virtual bool hasCustomExecutionPath() { return true; }
-  virtual test_results_t setup(ParameterDict &param);
-  virtual test_results_t executeTest();
+  bool hasCustomExecutionPath() override { return true; }
+  test_results_t setup(ParameterDict &param) override;
+  test_results_t executeTest() override;
 };
 extern "C" DLLEXPORT TestMutator *test_thread_6_factory() {
   return new test_thread_6_Mutator();
-}
-
-test_thread_6_Mutator::test_thread_6_Mutator()
-  : logfilename(NULL), bpatch(NULL), create_proc(true) {
 }
 
 #define NUM_THREADS 5
@@ -416,7 +409,6 @@ test_results_t test_thread_6_Mutator::executeTest() {
 test_results_t test_thread_6_Mutator::setup(ParameterDict &param) {
    /* Grab info from param */
    bpatch = (BPatch *)(param["bpatch"]->getPtr());
-   logfilename = param["logfilename"]->getString();
    
    thread_count.store(0U);
 
@@ -424,14 +416,8 @@ test_results_t test_thread_6_Mutator::setup(ParameterDict &param) {
        debug_flag = true;
    }
    
-   if ( param["createmode"]->getInt() != CREATE )
-   {
-      create_proc = false;
-   }
-   if (!bpatch->registerThreadEventCallback(BPatch_threadCreateEvent,
-					    newthr) ||
-       !bpatch->registerThreadEventCallback(BPatch_threadDestroyEvent,
-					    deadthr))
+   if (!bpatch->registerThreadEventCallback(BPatch_threadCreateEvent, newthr) ||
+       !bpatch->registerThreadEventCallback(BPatch_threadDestroyEvent, deadthr))
    {
       dprintf("%s[%d]:  failed to register thread callback\n",
 	      __FILE__, __LINE__);

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -105,7 +105,7 @@ static void deadthr(BPatch_process *my_proc, BPatch_thread *thr)
 
    if (my_proc != proc)
    {
-      logerror("[%s:%u] - Got invalid process: %p vs %p\n", __FILE__,
+      dprintf(stdout, "[%s:%u] - Got invalid process: %p vs %p\n", __FILE__,
 	      __LINE__, my_proc, proc);
       error13 = 1;
    }
@@ -122,13 +122,13 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr)
 
    if (my_proc != proc && proc != NULL && my_proc != NULL)
    {
-      logerror("[%s:%u] - Got invalid process: %p vs %p\n", 
+      dprintf(stdout, "[%s:%u] - Got invalid process: %p vs %p\n",
               __FILE__, __LINE__, my_proc, proc);
       error13 = 1;
    }
 
    if (thr->isDeadOnArrival()) {
-      logerror("[%s:%u] - Got a dead on arival thread\n", 
+      dprintf(stdout, "[%s:%u] - Got a dead on arival thread\n",
               __FILE__, __LINE__);
       error13 = 1;
       return;
@@ -136,7 +136,7 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr)
 
    unsigned my_dyn_id = our_tid_max; our_tid_max++;
    if (bpindex_to_myindex(thr->getBPatchID()) != -1) {
-      logerror("[%s:%d] - WARNING: Thread %d called in callback twice\n",
+      dprintf(stdout, "[%s:%d] - WARNING: Thread %d called in callback twice\n",
               __FILE__, __LINE__, thr->getBPatchID());
       error13 = 1;
       return;
@@ -170,7 +170,7 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr)
        // We can get unexpected threads with different initial functions; do not include
        // them (but don't consider it an error). If we don't walk the stack right, then
        // we won't have enough expected threads and so check it later.
-      logerror("[%s:%d] - Thread %d has unexpected initial function '%s'; ignoring\n",
+      dprintf(stdout, "[%s:%d] - Thread %d has unexpected initial function '%s'; ignoring\n",
               __FILE__, __LINE__, thr->getBPatchID(), name);
       //      error13 = 1; // This shouldn't be an error, according to the comment above.
       BPatch_Vector<BPatch_frame> stack;
@@ -436,7 +436,7 @@ test_results_t test_thread_6_Mutator::setup(ParameterDict &param) {
        !bpatch->registerThreadEventCallback(BPatch_threadDestroyEvent,
 					    deadthr))
    {
-      logerror("%s[%d]:  failed to register thread callback\n",
+      dprintf(stdout, "%s[%d]:  failed to register thread callback\n",
 	      __FILE__, __LINE__);
       return FAILED;
    }

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -204,6 +204,7 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   {
     std::vector<BPatch_thread *> threads;
     appProc->getThreads(threads);
+    dprintf("Found %z mutator threads\n", threads.size());
     for (auto *t : threads) {
       if (t == appThread)
         continue;
@@ -236,6 +237,7 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   {
     BPatch_Vector<BPatch_thread *> thrds;
     mutatee_process->getThreads(thrds);
+    dprintf("Found %z mutatee threads\n", thrds.size());
     if (thrds.size() != NUM_THREADS) {
       dprintf("[%s:%d] - Have %u threads, expected %u!\n", __FILE__, __LINE__,
               thrds.size(), NUM_THREADS);

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -279,10 +279,6 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   register_threads(this->appProc);
 
   auto terminate_mutatee = [this] {
-    // Be sure to have the threads in the mutatee resume so they aren't
-    // blocking on the barrier
-    upgrade_mutatee_state();
-    
     if (!this->appProc->isTerminated())
     	this->appProc->terminateExecution();
   };

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -282,6 +282,12 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
     dprintf("%s[%d]: ERROR during thread create stage, exiting\n", __FILE__,
             __LINE__);
     dprintf("*** Failed test_thread_6 (Threading Callbacks)\n");
+
+    // Be sure to have the threads in the mutatee resume so they aren't
+    // blocking on the barrier
+    upgrade_mutatee_state();
+
+    // Terminate the mutatee
     if (proc && !proc->isTerminated())
       proc->terminateExecution();
     return FAILED;

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -191,7 +191,7 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
       "__libc_start_main", "mainCRTStartup"};
 
   const bool found_name =
-      std::find(std::begin(initial_funcs), std::end(initial_funcs), name) ==
+      std::find(std::begin(initial_funcs), std::end(initial_funcs), name) !=
       std::end(initial_funcs);
 
   // Initial thread function detection is proving VERY difficult on Windows,

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -117,14 +117,12 @@ static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
   if (!thr) {
     dprintf("%s[%d]:  deadthr called without valid ptr to thr\n", __FILE__,
             __LINE__);
-    return;
   }
 
   const auto thr_bp_id = thr->getBPatchID();
   if (!exists(tids, tids_mtx, thr_bp_id)) {
     dprintf("%s[%d]:  deadthr called on unknown thread %u\n", __FILE__,
             __LINE__, thr_bp_id);
-    return;
   }
 
   if (my_proc != mutatee_process) {
@@ -151,7 +149,6 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
   if (thr->isDeadOnArrival()) {
     dprintf("[%s:%u] - Got a dead on arival thread\n", __FILE__, __LINE__);
     error13.store(1);
-    return;
   }
 
   const auto thr_bp_id = thr->getBPatchID();
@@ -166,14 +163,12 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
     dprintf("[%s:%d] - WARNING: Thread %u called in callback twice\n", __FILE__,
             __LINE__, thr_bp_id);
     error13.store(1);
-    return;
   }
 
   if (has_value(tids, tids_mtx, mytid)) {
     dprintf("[%s:%d] - WARNING: Thread %u has a duplicate tid (%d)\n", __FILE__,
             __LINE__, thr_bp_id, static_cast<int>(mytid));
     error13.store(1);
-    return;
   }
 
   insert(tids, tids_mtx, thr_bp_id, mytid);

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -203,8 +203,6 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
       ) != std::end(initial_funcs);
   // clang-format on
 
-  // Initial thread function detection is proving VERY difficult on Windows,
-  // currently leaving disabled.
   if (!found_name) {
     // We can get unexpected threads with different initial functions; do not
     // include them (but don't consider it an error). If we don't walk the

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -39,6 +39,7 @@
 #include <unordered_map>
 
 #include <pthread.h>
+#include <sys/types.h>
 
 class test_thread_6_Mutator : public DyninstMutator {
 protected:
@@ -117,6 +118,7 @@ bool has_value(Container const &c, std::mutex &m, Value v) {
 static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
   dprintf("%s[%d]:  welcome to deadthr\n", __FILE__, __LINE__);
   dprintf("deadthr: pthread tid is %u\n", pthread_self());
+  dprintf("deadthr: linux tid is %d\n", gettid());
   dprintf("In newthr, appProc=%x\n", my_proc);
   if (!thr) {
     dprintf("%s[%d]:  deadthr called without valid ptr to thr\n", __FILE__,
@@ -144,6 +146,7 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
   dprintf("%s[%d]:  welcome to newthr, error13 = %d\n", __FILE__, __LINE__,
           error13.load());
   dprintf("newthr: pthread tid is %u\n", pthread_self());
+  dprintf("newthr: linux tid is %d\n", gettid());
   dprintf("In newthr, appProc=%x\n", my_proc);
 
   if (my_proc != mutatee_process) {
@@ -392,6 +395,7 @@ test_results_t test_thread_6_Mutator::executeTest() {
   dprintf("In executeTest, this->appProc=%x, appProc=%x, mutatee_process=%x\n",
 		  this->appProc, appProc, mutatee_process);
   dprintf("executeTest: pthread tid is %u\n", pthread_self());
+  dprintf("executeTest: linux tid is %d\n", gettid());
 
   test_results_t rv = mutatorTest(bpatch);
 
@@ -425,6 +429,7 @@ test_results_t test_thread_6_Mutator::setup(ParameterDict &param) {
 
   dprintf("In setup, appProc = %x\n", appProc);
   dprintf("setup: pthread tid is %u\n", pthread_self());
+  dprintf("setup: linux tid is %d\n", gettid());
 
   return DyninstMutator::setup(param);
 }

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -143,21 +143,23 @@ static void newthr(BPatch_process *my_proc, BPatch_thread *thr)
    dyn_tids[my_dyn_id] = 1;
 
    dprintf("%s[%d]:  newthr: BPatchID = %d\n", __FILE__, __LINE__, thr->getBPatchID());
-   //Check initial function
-   // BUG(?) Make sure this variable gets initialized properly!
-   static char name[1024];
-   BPatch_function *f = thr->getInitialFunc();   
-   if (f) f->getName(name, 1024);
-   else strcpy(name, "<NONE>");
 
-   int found_name = 0;
-   for (unsigned i=0; i<NUM_FUNCS; i++)
-      if (!strcmp(name, initial_funcs[i]))
-      {
-         found_name = 1;
-         break;
-      }
-   dprintf("%s[%d]:  newthr: %s\n", __FILE__, __LINE__, name);
+	char name[128];
+	BPatch_function *f = thr->getInitialFunc();
+	if (f)
+		f->getName(name, sizeof(name));
+	else
+		strcpy(name, "<NONE>");
+	
+	dprintf("%s[%d]:  newthr: %s\n", __FILE__, __LINE__, name);
+
+	int found_name = 0;
+	for (unsigned i = 0; i < NUM_FUNCS; i++) {
+		if (!strcmp(name, initial_funcs[i])) {
+			found_name = 1;
+			break;
+		}
+	}
 
    //Initial thread function detection is proving VERY difficult on Windows,
    //currently leaving disabled.

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -68,14 +68,18 @@ namespace {
   std::atomic<unsigned> error13;
 
   bool debug_flag = false;
+  std::mutex print_mtx;
 
   constexpr auto NUM_THREADS = 5;
   constexpr auto TIMEOUT = 20;
 }
 
 template <typename... Args> static void dprintf(char const *fmt, Args... args) {
-  if (debug_flag)
+  if (debug_flag) {
+	std::lock_guard<std::mutex> l{print_mtx};
     fprintf(stdout, fmt, args...);
+    fflush(stdout);
+  }
 }
 
 template <typename Container, typename Value>

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -204,7 +204,7 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   {
     std::vector<BPatch_thread *> threads;
     appProc->getThreads(threads);
-    dprintf("Found %z mutator threads\n", threads.size());
+    dprintf("Found %uz mutator threads\n", threads.size());
     for (auto *t : threads) {
       if (t == appThread)
         continue;
@@ -237,7 +237,7 @@ test_results_t test_thread_6_Mutator::mutatorTest(BPatch *bpatch) {
   {
     BPatch_Vector<BPatch_thread *> thrds;
     mutatee_process->getThreads(thrds);
-    dprintf("Found %z mutatee threads\n", thrds.size());
+    dprintf("Found %uz mutatee threads\n", thrds.size());
     if (thrds.size() != NUM_THREADS) {
       dprintf("[%s:%d] - Have %u threads, expected %u!\n", __FILE__, __LINE__,
               thrds.size(), NUM_THREADS);

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -112,7 +112,7 @@ bool has_value(Container const &c, std::mutex &m, Value v) {
   return false;
 }
 
-static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
+static void deadthr(BPatch_process *, BPatch_thread *thr) {
   dprintf("%s[%d]:  welcome to deadthr\n", __FILE__, __LINE__);
 
   if (!thr) {
@@ -126,26 +126,15 @@ static void deadthr(BPatch_process *my_proc, BPatch_thread *thr) {
             __LINE__, thr_bp_id);
   }
 
-  if (my_proc != mutatee_process) {
-    dprintf("[%s:%u] - Got invalid process: %p vs %p\n", __FILE__, __LINE__,
-            my_proc, mutatee_process);
-    error13.store(1);
-  }
   remove(tids, tids_mtx, thr_bp_id);
   deleted_threads++;
   dprintf("%s[%d]:  leaving to deadthr, %d is dead, %d total dead threads\n",
           __FILE__, __LINE__, thr_bp_id, deleted_threads.load());
 }
 
-static void newthr(BPatch_process *my_proc, BPatch_thread *thr) {
+static void newthr(BPatch_process *, BPatch_thread *thr) {
   dprintf("%s[%d]:  welcome to newthr, error13 = %d\n", __FILE__, __LINE__,
           error13.load());
-
-  if (my_proc != mutatee_process) {
-    dprintf("[%s:%u] - Got invalid process: %p vs %p\n", __FILE__, __LINE__,
-            my_proc, mutatee_process);
-    error13.store(1);
-  }
 
   if (thr->isDeadOnArrival()) {
     dprintf("[%s:%u] - Got a dead on arival thread\n", __FILE__, __LINE__);

--- a/src/dyninst/test_thread_6.C
+++ b/src/dyninst/test_thread_6.C
@@ -194,20 +194,13 @@ void test_thread_6_Mutator::upgrade_mutatee_state() {
 
 BPatch_process *test_thread_6_Mutator::getProcess() { return appProc; }
 
-static void register_mutator_threads(
-    BPatch_process *appProc /*, BPatch_thread *appThread*/) {
-  // For the attach case, we may already have the threads in existence; if so,
-  // manually trigger them here.
+static void register_mutator_threads(BPatch_process *appProc) {
   std::vector<BPatch_thread *> threads;
   appProc->getThreads(threads);
   dprintf("Found %zu mutator threads\n", threads.size());
   for (auto *t : threads) {
-    //	  if (t == appThread)
-    //		continue;
     newthr(appProc, t);
   }
-
-  //	newthr(appProc, appThread);
 }
 
 static bool wait_mutatee_threads(BPatch *bpatch) {

--- a/src/dyninst/test_thread_6_mutatee.c
+++ b/src/dyninst/test_thread_6_mutatee.c
@@ -77,14 +77,18 @@ int test_thread_6_mutatee() {
 	done = 1;
 	testUnlock(&done_lock);
 
+	logstatus("[%s:%d]: stage 3 - atomic flag set\n", __FILE__, __LINE__);
+
 	for(int i=0; i<NUM_THREADS; i++) {
 		joinThread(thread_ids[i]);
 	}
 
-	logstatus("[%s:%d]: stage 3 - all threads joined\n", __FILE__, __LINE__);
+	logstatus("[%s:%d]: stage 4 - all threads joined\n", __FILE__, __LINE__);
 
 	testDestroyLock(&done_lock);
 	testBarrierDestroy(&startup_barrier);
+
+	logstatus("[%s:%d]: stage 5 - synchronization cleanup complete\n", __FILE__, __LINE__);
 
 	return 0;
 }

--- a/src/dyninst/test_thread_6_mutatee.c
+++ b/src/dyninst/test_thread_6_mutatee.c
@@ -41,7 +41,8 @@ testlock_t done_lock;
 // Barrier to synchronize thread startup
 testbarrier_t startup_barrier;
 
-static void* init_func(void *arg)
+// This must have external linkage so that the mutator can find the symbol
+void* init_func(void *arg)
 {
 	waitTestBarrier(&startup_barrier);
 	while(!done);

--- a/src/dyninst/test_thread_6_mutatee.c
+++ b/src/dyninst/test_thread_6_mutatee.c
@@ -27,70 +27,63 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <sys/types.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "mutatee_util.h"
 #include "solo_mutatee_boilerplate.h"
 
-#if !defined(os_windows_test)
-#include <unistd.h>
-#else
-#include <windows.h>
-#endif
+// This is modified by the mutator
+volatile int proc_current_state = 0;
 
-#define NTHRD 4
+// We only require C99, so we have to create our own "atomic"
+volatile int done = 0;
+testlock_t done_lock;
 
-volatile int done;
-volatile int proc_current_state;
-volatile int threads_running[NTHRD];
+// Barrier to synchronize thread startup
+testbarrier_t startup_barrier;
 
-void *init_func(void *arg)
+static void* init_func(void *arg)
 {
-   threads_running[(int) (long) arg] = 1;
-   while (!done);
-   return arg;
+	waitTestBarrier(&startup_barrier);
+	while(!done);
+	return arg;
 }
 
-/* int main(int argc, char *argv[]) */
 int test_thread_6_mutatee() {
-   unsigned i;
-   thread_t threads[NTHRD];
-   int startedall = 0;
+	const int NUM_THREADS = 4;
 
-   /* initThreads() has an empty function body? */
-   initThreads();
+	initBarrier(&startup_barrier, NUM_THREADS);
+	initLock(&done_lock);
+	initThreads();
 
-   for (i=0; i<NTHRD; i++)  {
-      threads[i] = spawnNewThread((void *) init_func, (void *) (long) i);
-   }
+	thread_t thread_ids[NUM_THREADS];
 
-   while (!startedall) {
-      for (i=0; i<NTHRD; i++) {
-         startedall = 1;
-         if (!threads_running[i]) {
-            startedall = 0;
-            P_sleep(1);
-            break;
-         }
-      }
-   }
+	for (int i=0; i<NUM_THREADS; i++) {
+		thread_ids[i] = spawnNewThread((void*)init_func, NULL);
+	}
 
-   handleAttach();
+	// Wait for mutator to attach (if in attach mode)
+	handleAttach();
 
-   logstatus("[%s:%d]: stage 1 - all threads created\n", __FILE__, __LINE__);
-   while (proc_current_state == 0) {
-     /* Do nothing */
-   }
-   logstatus("[%s:%d]: stage 2 - allowing threads to exit\n", __FILE__, __LINE__);
-   done = 1;
-   for (i=0; i<NTHRD; i++)
-   {
-      joinThread(threads[i]);
-   }
-   logstatus("[%s:%d]: stage 3 - all threads joined\n", __FILE__, __LINE__);
-   /* Is the return value of this mutatee checked?  Doesn't look like it */
-   return 0;
+	logstatus("[%s:%d]: stage 1 - all threads created\n", __FILE__, __LINE__);
+
+	// Wait until mutator has modified our state
+	while(proc_current_state == 0);
+
+	logstatus("[%s:%d]: stage 2 - allowing threads to exit\n", __FILE__, __LINE__);
+
+	// Flag all the threads to complete
+	testLock(&done_lock);
+	done = 1;
+	testUnlock(&done_lock);
+
+	for(int i=0; i<NUM_THREADS; i++) {
+		joinThread(thread_ids[i]);
+	}
+
+	logstatus("[%s:%d]: stage 3 - all threads joined\n", __FILE__, __LINE__);
+
+	testDestroyLock(&done_lock);
+	testBarrierDestroy(&startup_barrier);
+
+	return 0;
 }

--- a/src/dyninst/test_thread_6_mutatee.c
+++ b/src/dyninst/test_thread_6_mutatee.c
@@ -52,7 +52,8 @@ void* init_func(void *arg)
 int test_thread_6_mutatee() {
 	const int NUM_THREADS = 4;
 
-	initBarrier(&startup_barrier, NUM_THREADS);
+	// We need all of the threads _and_ the main thread to wait on the barrier
+	initBarrier(&startup_barrier, NUM_THREADS + 1);
 	initLock(&done_lock);
 	initThreads();
 
@@ -61,6 +62,9 @@ int test_thread_6_mutatee() {
 	for (int i=0; i<NUM_THREADS; i++) {
 		thread_ids[i] = spawnNewThread((void*)init_func, NULL);
 	}
+
+	// Make sure all of the threads have spooled up before proceeding
+	waitTestBarrier(&startup_barrier);
 
 	// Wait for mutator to attach (if in attach mode)
 	handleAttach();

--- a/src/dyninst/test_thread_6_mutatee.c
+++ b/src/dyninst/test_thread_6_mutatee.c
@@ -79,22 +79,20 @@ int test_thread_6_mutatee() {
 	// Wait until mutator has modified our state
 	while(proc_current_state == 0);
 
-	logstatus("[%s:%d]: stage 2 - allowing threads to exit\n", __FILE__, __LINE__);
+	logstatus("[%s:%d]: stage 2 - State changed by mutator; threads exiting\n", __FILE__, __LINE__);
 
 	// Flag all the threads to complete
 	done = 1;
-
-	logstatus("[%s:%d]: stage 3 - atomic flag set\n", __FILE__, __LINE__);
 
 	for(int i=0; i<NUM_THREADS; i++) {
 		joinThread(thread_ids[i]);
 	}
 
-	logstatus("[%s:%d]: stage 4 - all threads joined\n", __FILE__, __LINE__);
+	logstatus("[%s:%d]: stage 3 - all threads joined\n", __FILE__, __LINE__);
 
 	testBarrierDestroy(&startup_barrier);
 
-	logstatus("[%s:%d]: stage 5 - synchronization cleanup complete\n", __FILE__, __LINE__);
+	logstatus("[%s:%d]: stage 4 - synchronization cleanup complete\n", __FILE__, __LINE__);
 
 	return 0;
 }

--- a/src/mutatee_util.h
+++ b/src/mutatee_util.h
@@ -203,9 +203,11 @@ extern int threads_equal(thread_t a, thread_t b);
 extern void initThreads();
 
 extern void initLock(testlock_t *newlock);
+extern void testDestroyLock(testlock_t *);
 extern void testLock(testlock_t *lck);
 extern void testUnlock(testlock_t *lck);
 extern void initBarrier(testbarrier_t *barrier, unsigned int count);
+extern void testBarrierDestroy(testbarrier_t *);
 extern void waitTestBarrier(testbarrier_t *barrier);
 extern thread_t threadSelf();
 extern unsigned long thread_int(thread_t a);

--- a/src/mutatee_util_mt.c
+++ b/src/mutatee_util_mt.c
@@ -145,6 +145,10 @@ void initLock(testlock_t *newlock) {
    pthread_mutex_init((pthread_mutex_t *) newlock, NULL);
 }
 
+void testDestroyLock(testlock_t *lck) {
+	pthread_mutex_destroy((pthread_mutex_t*)lck);
+}
+
 void testLock(testlock_t *lck) {
    pthread_mutex_lock((pthread_mutex_t *) lck);
 }
@@ -164,6 +168,10 @@ void waitTestBarrier(testbarrier_t *barrier) {
 #else
 void initBarrier(testbarrier_t *barrier, unsigned int count) {
     pthread_barrier_init((pthread_barrier_t *)barrier, NULL, count);
+}
+
+void testBarrierDestroy(testbarrier_t *b) {
+	pthread_barrier_destroy((pthread_barrier_t*)b);
 }
 
 void waitTestBarrier(testbarrier_t *barrier) {


### PR DESCRIPTION
This also adds destruction functions for `testlock_t` and `testbarrier_t`.