### PR TITLE
Remove exception specifications

### DIFF
--- a/src/symtab/test_anno_basic_types.C
+++ b/src/symtab/test_anno_basic_types.C
@@ -74,7 +74,7 @@ class TestClassDense : public TestClass, public AnnotatableDense
 };
 
 template <class TC, class T>
-void remove_anno(TC &tcs, const char *anno_prefix_to_use = NULL) THROW_SPEC (LocErr)
+void remove_anno(TC &tcs, const char *anno_prefix_to_use = NULL)
 {
 	std::string an(typeid(T).name());
 
@@ -100,7 +100,7 @@ void remove_anno(TC &tcs, const char *anno_prefix_to_use = NULL) THROW_SPEC (Loc
 
 template <class TC, class T>
 void verify_anno(TC &tcs, const T &test_val, 
-		const char *anno_prefix_to_use = NULL) THROW_SPEC (LocErr)
+		const char *anno_prefix_to_use = NULL)
 {
 	std::string an(typeid(T).name());
 
@@ -126,7 +126,7 @@ void verify_anno(TC &tcs, const T &test_val,
 
 template <class TC, class T>
 void add_get_and_verify_anno(TC &tcs, const T &test_val, 
-		const char *anno_prefix_to_use = NULL) THROW_SPEC(LocErr)
+		const char *anno_prefix_to_use = NULL)
 {
 
    //  A very simple function that adds an annotation of type T to the given class
@@ -166,7 +166,7 @@ void add_get_and_verify_anno(TC &tcs, const T &test_val,
 
 template <class TC, class T>
 void add_verify_dispatch(TC &tcs, const T &test_val, bool do_add, 
-      const char *anno_prefix_to_use = NULL) THROW_SPEC (LocErr)
+      const char *anno_prefix_to_use = NULL)
 {
    if (do_add)
    {
@@ -179,7 +179,7 @@ void add_verify_dispatch(TC &tcs, const T &test_val, bool do_add,
 }
 
 template <class T>
-void test_for_annotatable() THROW_SPEC (LocErr)
+void test_for_annotatable()
 {
    T tc;
    bool do_add = false;

--- a/src/test_lib.C
+++ b/src/test_lib.C
@@ -110,7 +110,7 @@ LocErr::LocErr(const char *__file__, const int __line__, const std::string msg) 
 	line__(__line__)
 {}
 
-LocErr::~LocErr() THROW
+LocErr::~LocErr()
 {}
 
 std::string LocErr::file() const

--- a/src/test_lib.h
+++ b/src/test_lib.h
@@ -156,7 +156,7 @@ class LocErr
 			const int __line__,
 			const std::string msg); 
 
-	TESTLIB_DLL_EXPORT virtual ~LocErr() THROW; 
+	TESTLIB_DLL_EXPORT virtual ~LocErr();
 
 	TESTLIB_DLL_EXPORT std::string file() const;
 


### PR DESCRIPTION
They were deprecated in c++11 and removed in c++17.