### PR TITLE
Remove explicit template instantiations of BPatch_Vector

### DIFF
--- a/src/dyninst/test_callback_1.C
+++ b/src/dyninst/test_callback_1.C
@@ -68,7 +68,6 @@ static const char *expected_fnames[] = {"call2_1","call2_2","call2_3","call2_4"}
 static int test2done = 0;
 static int test2err = 0;
 static int mutateeXLC = 0;
-template class BPatch_Vector<void *>;
 static BPatch_Vector<BPatch_point *> test2handles;
 static BPatch_Vector<BPatch_point *> dyncalls;
 static BPatch_process *globalThread = NULL;

--- a/src/dyninst/test_thread_1.C
+++ b/src/dyninst/test_thread_1.C
@@ -64,7 +64,6 @@ static int mutateeXLC;
 static const char *expected_fnames[] = {"call1_1","call1_2","call1_3","call1_4"};
 static int test1done = 0;
 static int test1err = 0;
-template class BPatch_Vector<void *>;
 static BPatch_Vector<void *> test1handles;
 static BPatch_Vector<BPatch_point *> dyncalls;
 


### PR DESCRIPTION
BPatch_Vector is now an alias template.
See https://github.com/dyninst/dyninst/pull/844 for details.