### PR TITLE
Warn on missing compiler paths instead of dying

### DIFF
--- a/scripts/build/Dyninst/utils.pm
+++ b/scripts/build/Dyninst/utils.pm
@@ -83,7 +83,7 @@ sub save_compiler_config {
 	for my $c (keys %compilers) {
 		for my $t (keys %{$compilers{$c}}) {
 			unless($compilers{$c}{$t}) {
-				die "$cmake_log is missing $c/$t\n";
+				warn "$cmake_log is missing $c/$t\n";
 			}
 		}
 	}


### PR DESCRIPTION
CMake keeps changing how it formats these, so just skip it, if we don't find it.