### PR TITLE
nasm is being deprecated.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,9 +99,10 @@ set(INSTALL_DIR "bin/testsuite" CACHE PATH "Testsuite installation directory")
 
 if(UNIX)
   enable_language(ASM-ATT)
-  if("${DYNINST_PLATFORM}" MATCHES "i386")
-    enable_language(ASM_NASM)
-  endif()
+# nasm/yasm are deprecated
+#  if("${DYNINST_PLATFORM}" MATCHES "i386")
+#    enable_language(ASM_NASM)
+#  endif()
 elseif(WIN32)
   enable_language(ASM_MASM)
   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 19)


### PR DESCRIPTION
nasm is being deprecated on Linux.  This test seems to only be run for x86.   This simply does not run the test.  Is the purpose to test instrumentation with assembler source?  Perhaps on Linux  the test could be converted to gas.