### PR TITLE
Allow non-HTTPS connection when uploading to dashboard

### DIFF
--- a/scripts/build/build.pl
+++ b/scripts/build/build.pl
@@ -305,7 +305,7 @@ if($args{'purge'}) {
 if($args{'upload'}) {
 	eval {
 		Dyninst::utils::execute(
-			"curl -F \"upload=\@$root_dir.results.tar.gz\" ".
+			"curl --insecure -F \"upload=\@$root_dir.results.tar.gz\" ".
 			"-F \"token=$args{'auth-token'}\" ".
 			"https://bottle.cs.wisc.edu/upload"
 		);


### PR DESCRIPTION
Some machines are configured to not allow non-HTTPS traffic by default.