### PR TITLE
make cmp function object operator() a const func

### DIFF
--- a/src/instruction/instruction_comp.h
+++ b/src/instruction/instruction_comp.h
@@ -44,7 +44,7 @@ class COMPLIB_DLL_EXPORT InstructionMutator : public TestMutator {
      template <typename T>
         struct shared_ptr_lt
      {
-         bool operator()(const T& lhs, const T& rhs)
+         bool operator()(const T& lhs, const T& rhs) const
          {
              // Non-nulls precede nulls
              if(rhs.get() == NULL)


### PR DESCRIPTION
STL in C++17 requires this

fixes #198