### PR TITLE
Remove serialization

### DIFF
--- a/src/CmdLine.C
+++ b/src/CmdLine.C
@@ -119,7 +119,6 @@ ModeGroup mode_args[] = {
    { "create",      RUNMODES,  defaultOn  },
    { "attach",      RUNMODES,  defaultOff },
    { "rewriter",    RUNMODES,  defaultOn  },
-   { "serialize",   RUNMODES,  defaultOff },
    { "max",         OPTLEVELS, defaultOff },
    { "high",        OPTLEVELS, defaultOff },
    { "low",         OPTLEVELS, defaultOff },
@@ -726,8 +725,7 @@ static void disableUnwantedTests(std::vector<RunGroup *> &groups)
       //RunMode
       if (((groups[i]->createmode == CREATE) && !paramOn("create")) ||
           ((groups[i]->createmode == USEATTACH) && !paramOn("attach")) ||
-          ((groups[i]->createmode == DISK) && !paramOn("rewriter")) ||
-          ((groups[i]->createmode == DESERIALIZE) && !paramOn("serialize")))
+          ((groups[i]->createmode == DISK) && !paramOn("rewriter")))
       {
          groups[i]->disabled = true;
          continue;

--- a/src/TestData.h
+++ b/src/TestData.h
@@ -50,8 +50,7 @@ enum start_state_t {
 enum create_mode_t {
    CREATE = 0,
    USEATTACH,
-   DISK,
-   DESERIALIZE //Keep deserialize last to maintain proper sort
+   DISK
 };
 
 enum cleanup_mode_t {

--- a/src/dyninst/dyninst_comp.C
+++ b/src/dyninst/dyninst_comp.C
@@ -222,11 +222,6 @@ test_results_t DyninstComponent::group_setup(RunGroup *group,
          }
          break;
       }
-      case DESERIALIZE:
-      {
-         assert(0); //Don't know how to handle this;
-         break;
-      }
    }
    
 

--- a/src/specification/makemake.py
+++ b/src/specification/makemake.py
@@ -900,10 +900,7 @@ void initialize_mutatees_%s(std::vector<RunGroup *> &tests) {
 			# I need to get the mutator that this test maps to..
 			mutator = test_mutator(test)
 			ts = build_label(test, mutator, group)
-			if test in ['test_serializable']:
-				serialize_enable = 'true'
-			else:
-				serialize_enable = 'false'
+			serialize_enable = 'false'
 			test_params.append({'test': test, 'mutator': mutator, 'LibSuffix': LibSuffix, 'serialize_enable' : serialize_enable, 'ts': ts, 'endrungroup': 'false'})
 		test_params[-1]['endrungroup'] = 'true'
 		if(group_empty == 'false'):
@@ -942,7 +939,6 @@ void initialize_mutatees_%s(std::vector<RunGroup *> &tests) {
     const char * iname;
     const char * mrname;
     const char * isoname;
-	bool serialize_enable;
     const char * ilabel;
   } test_params[] = {"""
 

--- a/src/specification/test_info_new_gen.py
+++ b/src/specification/test_info_new_gen.py
@@ -92,8 +92,6 @@ void initialize_mutatees(std::vector<RunGroup *> &t) {
 			out.write('CREATE, ')
 		elif group['run_mode'] == 'useAttach':
 			out.write('USEATTACH, ')
-		elif group['run_mode'] == 'deserialize':
-			out.write('DESERIALIZE, ')
 		else:
 			out.write('DISK, ')
 
@@ -158,10 +156,7 @@ void initialize_mutatees(std::vector<RunGroup *> &t) {
 			# I need to get the mutator that this test maps to..
 			mutator = test_mutator(test, info)
 			ts = build_label(test, mutator, group, info)
-			if test in ['test_serializable']:
-				serialize_enable = 'true'
-			else:
-				serialize_enable = 'false'
+			serialize_enable = 'false'
 			out.write('  add_test(rg, "%s");\n' % (ts))
 		out.write('  fini_group(rg);\n')
 

--- a/src/symtab/test_exception.C
+++ b/src/symtab/test_exception.C
@@ -54,8 +54,6 @@ extern "C" DLLEXPORT TestMutator* test_exception_factory()
 
 test_results_t test_exception_Mutator::executeTest()
 {
-	if (createmode == DESERIALIZE)
-		return SKIPPED;
 #if defined (os_windows_test)
 	return SKIPPED;
 #endif

--- a/src/symtab/test_line_info.C
+++ b/src/symtab/test_line_info.C
@@ -161,9 +161,6 @@ test_results_t test_line_info_Mutator::basic_verification()
 
 test_results_t test_line_info_Mutator::executeTest()
 {
-
-	if (createmode == DESERIALIZE)
-		return SKIPPED;
 	if (FAILED == basic_verification())
 	{
 		logerror( "%s[%d]:  failed basic verifications, skipping rest...\n", 

--- a/src/symtab/test_lookup_func.C
+++ b/src/symtab/test_lookup_func.C
@@ -52,8 +52,6 @@ extern "C" DLLEXPORT TestMutator* test_lookup_func_factory()
 
 test_results_t test_lookup_func_Mutator::executeTest()
 {
-	if (createmode == DESERIALIZE)
-		return SKIPPED;
     std::vector<Symbol*> funcSyms;
     bool result = symtab->getAllSymbolsByType(funcSyms, Symbol::ST_FUNCTION);
     if(result == false)

--- a/src/symtab/test_lookup_var.C
+++ b/src/symtab/test_lookup_var.C
@@ -51,8 +51,6 @@ extern "C" DLLEXPORT TestMutator* test_lookup_var_factory()
 
 test_results_t test_lookup_func_Mutator::executeTest()
 {
-	if (createmode == DESERIALIZE)
-		return SKIPPED;
    std::vector<Variable *> vars;
    bool result = symtab->findVariablesByName(vars, std::string("lookup_var"));
 

--- a/src/symtab/test_module.C
+++ b/src/symtab/test_module.C
@@ -85,8 +85,6 @@ bool malformed_module(SymtabAPI::Module *mod)
 
 test_results_t test_module_Mutator::executeTest()
 {
-	if (createmode == DESERIALIZE)
-		return SKIPPED;
    std::vector<SymtabAPI::Module *> mods;
    bool result = symtab->getAllModules(mods);
 

--- a/src/symtab/test_relocations.C
+++ b/src/symtab/test_relocations.C
@@ -136,8 +136,6 @@ extern "C" DLLEXPORT TestMutator* test_relocations_factory()
 
 test_results_t test_relocations_Mutator::executeTest()
 {
-	if (createmode == DESERIALIZE)
-		return SKIPPED;
 #if defined (os_windows_test)
 	return SKIPPED;
 #endif

--- a/src/symtab/test_type_info.C
+++ b/src/symtab/test_type_info.C
@@ -1089,14 +1089,6 @@ test_results_t test_type_info_Mutator::verify_basic_type_lists() {
 }
 
 test_results_t test_type_info_Mutator::executeTest() {
-
-  if (createmode == DESERIALIZE)
-    return SKIPPED;
-#if defined(os_linux_test) && defined(arch_x86_test)
-  if ((createmode == DESERIALIZE) && (compiler == std::string("g++")))
-    return SKIPPED;
-#endif
-
   SymtabAPI::Module *mod = NULL;
   std::vector<SymtabAPI::Module *> mods;
 

--- a/src/test_info_new.C
+++ b/src/test_info_new.C
@@ -54,9 +54,8 @@ static const char *extract_name(const char *tag, const char *label)
 
 // The constructor for TestInfo
 TestInfo::TestInfo(unsigned int i, const char *iname, const char *imrname,
-                   const char *isoname, bool _serialize_enable, const char *ilabel) :
+                   const char *isoname, const char *ilabel) :
 	index(i), name(iname), mutator_name(imrname), soname(isoname),
-	serialize_enable(_serialize_enable),
 	label(ilabel), mutator(NULL), disabled(false), limit_disabled(false),
 	enabled(false), result_reported(false)
 {
@@ -73,7 +72,6 @@ TestInfo::TestInfo(unsigned int i, const char *iname, const char *imrname,
 
 TestInfo::TestInfo(unsigned int i, const char *libsuffix, const char *ilabel) :
    index(i),
-   serialize_enable(false),
    label(ilabel),
    mutator(NULL),
    disabled(false),

--- a/src/test_info_new.h
+++ b/src/test_info_new.h
@@ -101,7 +101,6 @@ public:
   const char *soname;
   const char *label;
   TestMutator *mutator;
-  bool serialize_enable;
   bool disabled;
   bool limit_disabled;
   bool enabled;
@@ -115,7 +114,7 @@ public:
   TESTLIB_DLL_EXPORT static int getMaxTestNameLength();
   TESTLIB_DLL_EXPORT static void setMaxTestNameLength(int newlen);
   TESTLIB_DLL_EXPORT TestInfo(unsigned int i, const char *iname, const char *mrname,
-                              const char *isoname, bool _serialize_enable, const char *ilabel);
+                              const char *isoname, const char *ilabel);
   TESTLIB_DLL_EXPORT TestInfo(unsigned int i, const char *sosuffix, const char *ilabel);
   TESTLIB_DLL_EXPORT ~TestInfo();
 };


### PR DESCRIPTION
This was removed from Dyninst by f4ee3410b in 2020.

@bigtrak I think I've removed enough from the python scripts to make sure serialization isn't re-introduced when files are regenerated. Could you double-check?