### PR TITLE
Use target-based TBB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ set(CMAKE_MODULE_PATH
     "${Dyninst_DIR}/Modules")
 
 include(optimization)
-include(ThreadingBuildingBlocks REQUIRED)
 
 # CMake tries to auto-add flags to link lines, which isn't helpful.  Blanking
 # this variable should fix.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ load_cache(${Dyninst_DIR}
 # NB: ElfUtils is not (currently) used directly in
 #     Testsuite, but is transitively included from headers
 #     in Dyninst.
+include_directories(${Boost_INCLUDE_DIRS})
+link_directories(${Boost_LIBRARY_DIRS})
+add_definitions(${Boost_DEFINES})
+
 include_directories(${ElfUtils_INCLUDE_DIRS})
 link_directories(${ElfUtils_LIBRARY_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,6 @@ load_cache(${Dyninst_DIR}
            Boost_INCLUDE_DIRS
            Boost_LIBRARY_DIRS
            Boost_DEFINES
-           TBB_INCLUDE_DIRS
-           TBB_LIBRARY_DIRS
-           TBB_DEFINES
            ElfUtils_INCLUDE_DIRS
            ElfUtils_LIBRARY_DIRS
            STERILE_BUILD
@@ -44,17 +41,9 @@ load_cache(${Dyninst_DIR}
            )
 
 # Import the include and library directory names
-# NB: TBB and ElfUtils are not (currently) used directly in
-#     Testsuite, but are transitively included from headers
+# NB: ElfUtils is not (currently) used directly in
+#     Testsuite, but is transitively included from headers
 #     in Dyninst.
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
-add_definitions(${Boost_DEFINES})
-
-include_directories(${TBB_INCLUDE_DIRS})
-link_directories(${TBB_LIBRARY_DIRS})
-add_definitions(${TBB_DEFINES})
-
 include_directories(${ElfUtils_INCLUDE_DIRS})
 link_directories(${ElfUtils_LIBRARY_DIRS})
 
@@ -70,6 +59,7 @@ set(CMAKE_MODULE_PATH
     "${Dyninst_DIR}/Modules")
 
 include(optimization)
+include(ThreadingBuildingBlocks REQUIRED)
 
 # CMake tries to auto-add flags to link lines, which isn't helpful.  Blanking
 # this variable should fix.

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -148,7 +148,7 @@ sub run_tests {
 	my ($args, $base_dir, $run_log) = @_;
 
 	# Grab the paths in the Dyninst build cache
-	my @lib_dirs = ('Boost_LIBRARY_DIRS', 'TBB_LIBRARY_DIRS', 'ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
+	my @lib_dirs = ('Boost_LIBRARY_DIRS', 'ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
 	my $cache    = "$args->{'dyninst-cmake-cache-dir'}/CMakeCache.txt";
 	my @libs     = load_from_cache($cache, \@lib_dirs);
 


### PR DESCRIPTION
Dyninst now uses target-based TBB builds, so we need to explicitly provide TBB here. This is a temporary fix until Dyninst exports its targets.