### PR TITLE
Remove usage of Dyninst modules for config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,9 @@ set(CMAKE_MODULE_PATH
     "${Dyninst_DIR}"
     "${Dyninst_DIR}/Modules")
 
-include(optimization)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 
 # CMake tries to auto-add flags to link lines, which isn't helpful.  Blanking
 # this variable should fix.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,15 @@ list(INSERT CMAKE_MODULE_PATH 0
     "${PROJECT_SOURCE_DIR}/cmake/Modules"
     "${Dyninst_DIR}")
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+
+# CMake tries to auto-add flags to link lines, which isn't helpful.  Blanking
+# this variable should fix.
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
 include(LanguageStandards)
 include(optimization)
 
@@ -69,15 +78,6 @@ link_directories(${ElfUtils_LIBRARY_DIRS})
 if(NOT ${USE_GNU_DEMANGLER})
 	link_directories(${LibIberty_LIBRARY_DIRS})
 endif()
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE RelWithDebInfo)
-endif()
-
-# CMake tries to auto-add flags to link lines, which isn't helpful.  Blanking
-# this variable should fix.
-set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
-set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
 find_package(Dyninst REQUIRED
              COMPONENTS common

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,13 @@ endif()
 
 set(Dyninst_DIR ${_dyninst_dir} CACHE PATH "Location of Dyninst cmake files")
 
-set (CMAKE_MODULE_PATH "${Dyninst_DIR}" "${Dyninst_DIR}/Modules" ${CMAKE_MODULE_PATH})
+list(INSERT CMAKE_MODULE_PATH 0
+    "${PROJECT_SOURCE_DIR}/cmake"
+    "${PROJECT_SOURCE_DIR}/cmake/Modules"
+    "${Dyninst_DIR}")
 
-set(CMAKE_CXX_STANDARD "11")
-set(CMAKE_C_STANDARD "11")
+include(LanguageStandards)
+include(optimization)
 
 # Allow usage of GNU library extensions to ISOC99
 add_definitions(-D_GNU_SOURCE)
@@ -66,13 +69,6 @@ link_directories(${ElfUtils_LIBRARY_DIRS})
 if(NOT ${USE_GNU_DEMANGLER})
 	link_directories(${LibIberty_LIBRARY_DIRS})
 endif()
-
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${PROJECT_SOURCE_DIR}/cmake"
-    "${PROJECT_SOURCE_DIR}/cmake/Modules"
-    "${Dyninst_DIR}"
-    "${Dyninst_DIR}/Modules")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ set(Dyninst_DIR ${_dyninst_dir} CACHE PATH "Location of Dyninst cmake files")
 
 set (CMAKE_MODULE_PATH "${Dyninst_DIR}" "${Dyninst_DIR}/Modules" ${CMAKE_MODULE_PATH})
 
-# Set the C and C++ language API and ABI standards
-include(LanguageStandards)
+set(CMAKE_CXX_STANDARD "11")
+set(CMAKE_C_STANDARD "11")
 
 # Allow usage of GNU library extensions to ISOC99
 add_definitions(-D_GNU_SOURCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.13.0)
+
+# There is a bug in 3.19.0 that causes .S files to be treated like C files
+if(CMAKE_VERSION VERSION_EQUAL "3.19.0")
+    message(FATAL_ERROR "Dyninst cannot use CMake version 3.19.0")
+endif()
+
 project(Dyninst-TestSuite)
 
 # User must provide location of Dyninst cmake files either as a cache or

--- a/cmake/LanguageStandards.cmake
+++ b/cmake/LanguageStandards.cmake
@@ -1,0 +1,48 @@
+#=========================================================================
+# LanguageStandards.cmake
+#
+# Configure C++ and C Language API and ABI standards for Dyninst
+#
+#=========================================================================
+
+#
+# C/C++ language standard cmake options.
+#
+
+set(DYNINST_CXX_LANGUAGE_STANDARD
+    "11"
+    CACHE STRING "C++ language standard version.")
+set(DYNINST_C_LANGUAGE_STANDARD
+    "11"
+    CACHE STRING "C language standard version.")
+
+#
+# --------  C++ language features ----------------
+#
+
+# Disable compiler-specific C++ language extensions (e.g., gnu++11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Require C++11 support
+set(CMAKE_CXX_STANDARD ${DYNINST_CXX_LANGUAGE_STANDARD})
+message(STATUS "C++ language standard:  ${DYNINST_CXX_LANGUAGE_STANDARD}")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Require the standards-compliant C++11 ABI for gcc
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0")
+        message(FATAL_ERROR "Dyninst requires gcc >= 6.0")
+    endif()
+endif()
+
+#
+# --------  C language features ----------------
+#
+
+# Disable compiler-specific C language extensions (e.g., gnu99)
+set(CMAKE_C_EXTENSIONS OFF)
+
+# Require C11 support
+set(CMAKE_C_STANDARD ${DYNINST_C_LANGUAGE_STANDARD})
+message(STATUS "C language standard:  ${DYNINST_C_LANGUAGE_STANDARD}")
+set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/cmake/optimization.cmake
+++ b/cmake/optimization.cmake
@@ -1,0 +1,56 @@
+if(CMAKE_COMPILER_IS_GNUCXX
+   OR ${CMAKE_C_COMPILER_ID} MATCHES Clang
+   OR ${CMAKE_C_COMPILER_ID} MATCHES GNU
+   OR ${CMAKE_C_COMPILER_ID} MATCHES Intel)
+    if(ENABLE_LTO)
+        set(LTO_FLAGS "-flto")
+        set(LTO_LINK_FLAGS "-fuse-ld=bfd")
+    else()
+        set(LTO_FLAGS "")
+        set(LTO_LINK_FLAGS "")
+    endif()
+    set(CMAKE_C_FLAGS_DEBUG "-Og -g3")
+    set(CMAKE_CXX_FLAGS_DEBUG "-Og -g3")
+
+    set(CMAKE_C_FLAGS_RELEASE "-O2 ${LTO_FLAGS}")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${LTO_FLAGS}")
+
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g3 ${LTO_FLAGS}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g3 ${LTO_FLAGS}")
+
+    set(CMAKE_C_FLAGS_MINSIZEREL "-Os ${LTO_FLAGS}")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os ${LTO_FLAGS}")
+
+    set(FORCE_FRAME_POINTER "-fno-omit-frame-pointer")
+    # Ensure each library is fully linked
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LTO_LINK_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LTO_LINK_FLAGS}")
+else(MSVC)
+    if(ENABLE_LTO)
+        set(LTO_FLAGS "/GL")
+        set(LTO_LINK_FLAGS "/LTCG")
+    else()
+        set(LTO_FLAGS "")
+        set(LTO_LINK_FLAGS "")
+    endif()
+    set(CMAKE_C_FLAGS_DEBUG "/MP /Od /Zi /MDd /D_DEBUG")
+    set(CMAKE_CXX_FLAGS_DEBUG "/MP /Od /Zi /MDd /D_DEBUG")
+
+    set(CMAKE_C_FLAGS_RELEASE "/MP /O2 /MD ${LTO_FLAGS}")
+    set(CMAKE_CXX_FLAGS_RELEASE "/MP /O2 /MD ${LTO_FLAGS}")
+
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "/MP /O2 /Zi /MD ${LTO_FLAGS}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MP /O2 /Zi /MD ${LTO_FLAGS}")
+
+    set(CMAKE_C_FLAGS_MINSIZEREL "/MP /O1 /MD ${LTO_FLAGS}")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL "/MP /O1 /MD ${LTO_FLAGS}")
+
+    set(FORCE_FRAME_POINTER "/Oy-")
+
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LTO_LINK_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LTO_LINK_FLAGS}")
+    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} ${LTO_LINK_FLAGS}")
+endif()
+message(STATUS "Set optimization flags")


### PR DESCRIPTION
Removing these here will allow us to not have to export them in Dyninst. That make those modules internal to Dyninst and we can freely change them without worrying about bothering users. Also update to CMake 3.13.0 with same exception for 3.19.0 as in Dyninst.

It's also pretty much irrelevant how we build the mutators. The big concern is for the mutatees, and the flags provided by Dyninst aren't used for that.

This would be for the 13.0 release.