### PR TITLE
Add missing transitive include of 'time.h'

### DIFF
--- a/src/CmdLine.C
+++ b/src/CmdLine.C
@@ -35,10 +35,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <algorithm>
-
-#if defined(os_windows_test)
 #include <time.h>
-#endif
 
 #include "help.h"
 #include "CmdLine.h"


### PR DESCRIPTION
The STL from gcc-12.2 appears to have rearranged their headers to remove this transitive include.