### PR TITLE
Fix race in thread 3 due to not re-reading values.

### DIFF
--- a/src/dyninst/test_thread_3_mutatee.c
+++ b/src/dyninst/test_thread_3_mutatee.c
@@ -53,7 +53,7 @@
 
 Thread_t test4_threads[TEST3_THREADS];
 Lock_t test4lock;
-int mutateeIdle = 0;
+volatile int mutateeIdle = 0;
 
 /* Function definitions follow */
 


### PR DESCRIPTION
Fix race condition with test thread 3 by using volatile to assure that the value is re-read on updates.