### PR TITLE
CMake modernization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 set(COMPLIB_DEFS TESTLIB_DLL_BUILD COMPLIB_DLL_BUILD)
 
-if(TARGET dyninstAPI)
+if(TARGET Dyninst::dyninstAPI)
   add_library(testdyninst
               SHARED
               src/dyninst/dyninst_comp.C
@@ -141,56 +141,56 @@ if(TARGET dyninstAPI)
   target_link_libraries(testdyninst
                         testlaunch
                         testSuite
-                        dyninstAPI
-                        instructionAPI
-                        common
+                        Dyninst::dyninstAPI
+                        Dyninst::instructionAPI
+                        Dyninst::common
                         ${CMAKE_THREAD_LIBS_INIT})
   install(TARGETS testdyninst DESTINATION ${INSTALL_DIR})
   set_target_properties(testdyninst
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
 endif()
 
-if(TARGET symtabAPI)
+if(TARGET Dyninst::symtabAPI)
   add_library(testsymtab SHARED src/symtab/symtab_comp.C)
   target_link_libraries(testsymtab
                         testSuite
-                        symtabAPI
-                        common
+                        Dyninst::symtabAPI
+                        Dyninst::common
                         ${CMAKE_THREAD_LIBS_INIT})
   install(TARGETS testsymtab DESTINATION ${INSTALL_DIR})
   set_target_properties(testsymtab
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
 endif()
 
-if(TARGET instructionAPI)
+if(TARGET Dyninst::instructionAPI)
   add_library(testinstruction SHARED src/instruction/instruction_comp.C)
   target_link_libraries(testinstruction
                         testSuite
-                        instructionAPI
-                        symtabAPI
-                        common
+                        Dyninst::instructionAPI
+                        Dyninst::symtabAPI
+                        Dyninst::common
                         ${CMAKE_THREAD_LIBS_INIT})
   install(TARGETS testinstruction DESTINATION ${INSTALL_DIR})
   set_target_properties(testinstruction
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
 endif()
 
-if(TARGET pcontrol)
+if(TARGET Dyninst::pcontrol)
   add_library(testproccontrol SHARED src/proccontrol/proccontrol_comp.C)
 
   if(WIN32)
     target_link_libraries(testproccontrol
                           testSuite
-                          pcontrol
-                          common
+                          Dyninst::pcontrol
+                          Dyninst::common
                           ${CMAKE_THREAD_LIBS_INIT}
                           ws2_32)
   else()
     target_link_libraries(testproccontrol
                           testlaunch
                           testSuite
-                          pcontrol
-                          common
+                          Dyninst::pcontrol
+                          Dyninst::common
                           ${CMAKE_THREAD_LIBS_INIT})
   endif()
   install(TARGETS testproccontrol DESTINATION ${INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,11 @@ add_definitions(-D_GNU_SOURCE)
 # Import the system threads library
 find_package(Threads)
 
-set(_dyn_libs symtabAPI dyninstAPI pcontrol instructionAPI)
+set(_dyn_libs symtabAPI dyninstAPI pcontrol instructionAPI dyninstAPI_RT dyninstAPI_RT_static)
 find_package(Dyninst REQUIRED COMPONENTS ${_dyn_libs})
 
+# Make the aliases for the old-style targets
+#  The mutatees don't support the new style
 foreach(l ${_dyn_libs})
 	add_library(${l} INTERFACE IMPORTED)
 	target_link_libraries(${l} INTERFACE Dyninst::${l})
@@ -276,14 +278,6 @@ set_target_properties(testB_static PROPERTIES OUTPUT_NAME testB)
 
 if(UNIX)
   add_library(Test12 SHARED src/dyninst/libTest12.c)
-  add_library(dyninstAPI_RT SHARED IMPORTED)
-  set(_path_suffixes dyninst)
-  find_library(dyninstAPI_RT_LIBRARY
-             NAMES libdyninstAPI_RT.so
-             PATHS ${Dyninst_DIR}/../..
-             PATH_SUFFIXES ${_path_suffixes}
-             NO_DEFAULT_PATH)
-  set_target_properties(dyninstAPI_RT PROPERTIES IMPORTED_LOCATION ${dyninstAPI_RT_LIBRARY})
   target_link_libraries(Test12 dyninstAPI_RT)
   install(TARGETS Test12
           LIBRARY DESTINATION ${INSTALL_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13.0)
 
 # There is a bug in 3.19.0 that causes .S files to be treated like C files
 if(CMAKE_VERSION VERSION_EQUAL "3.19.0")
-    message(FATAL_ERROR "Dyninst cannot use CMake version 3.19.0")
+    message(FATAL_ERROR "Test Suite cannot use CMake version 3.19.0")
 endif()
 
 project(Dyninst-TestSuite)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ endif()
 
 set(COMPLIB_DEFS TESTLIB_DLL_BUILD COMPLIB_DLL_BUILD)
 
-if(TARGET Dyninst::dyninstAPI)
   add_library(testdyninst
               SHARED
               src/dyninst/dyninst_comp.C
@@ -156,9 +155,7 @@ if(TARGET Dyninst::dyninstAPI)
   install(TARGETS testdyninst DESTINATION ${INSTALL_DIR})
   set_target_properties(testdyninst
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
-endif()
 
-if(TARGET Dyninst::symtabAPI)
   add_library(testsymtab SHARED src/symtab/symtab_comp.C)
   target_link_libraries(testsymtab
                         testSuite
@@ -168,9 +165,7 @@ if(TARGET Dyninst::symtabAPI)
   install(TARGETS testsymtab DESTINATION ${INSTALL_DIR})
   set_target_properties(testsymtab
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
-endif()
 
-if(TARGET Dyninst::instructionAPI)
   add_library(testinstruction SHARED src/instruction/instruction_comp.C)
   target_link_libraries(testinstruction
                         testSuite
@@ -181,9 +176,7 @@ if(TARGET Dyninst::instructionAPI)
   install(TARGETS testinstruction DESTINATION ${INSTALL_DIR})
   set_target_properties(testinstruction
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
-endif()
 
-if(TARGET Dyninst::pcontrol)
   add_library(testproccontrol SHARED src/proccontrol/proccontrol_comp.C)
 
   if(WIN32)
@@ -204,7 +197,6 @@ if(TARGET Dyninst::pcontrol)
   install(TARGETS testproccontrol DESTINATION ${INSTALL_DIR})
   set_target_properties(testproccontrol
                         PROPERTIES COMPILE_DEFINITIONS "${COMPLIB_DEFS}")
-endif()
 
 if(WIN32)
   set(RUNTESTS_UTILS src/runTests-utils-nt.C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ load_cache(${Dyninst_DIR}
            Boost_INCLUDE_DIRS
            Boost_LIBRARY_DIRS
            Boost_DEFINES
-           TBB_INCLUDE_DIRS
-           TBB_LIBRARY_DIRS
-           TBB_DEFINES
            ElfUtils_INCLUDE_DIRS
            ElfUtils_LIBRARY_DIRS
            STERILE_BUILD
@@ -61,16 +58,12 @@ load_cache(${Dyninst_DIR}
            )
 
 # Import the include and library directory names
-# NB: TBB and ElfUtils are not (currently) used directly in
-#     Testsuite, but are transitively included from headers
+# NB: ElfUtils is not (currently) used directly in
+#     Testsuite, but is transitively included from headers
 #     in Dyninst.
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 add_definitions(${Boost_DEFINES})
-
-include_directories(${TBB_INCLUDE_DIRS})
-link_directories(${TBB_LIBRARY_DIRS})
-add_definitions(${TBB_DEFINES})
 
 include_directories(${ElfUtils_INCLUDE_DIRS})
 link_directories(${ElfUtils_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,7 @@ add_definitions(-D_GNU_SOURCE)
 # Import the system threads library
 find_package(Threads)
 
-find_package(Dyninst REQUIRED
-             COMPONENTS common
-             OPTIONAL_COMPONENTS symtabAPI
-                                 dyninstAPI
-                                 instructionAPI
-                                 proccontrol)
+find_package(Dyninst REQUIRED COMPONENTS symtabAPI dyninstAPI pcontrol instructionAPI)
 
 message(STATUS "Dyninst includes: ${DYNINST_INCLUDE_DIR}")
 include_directories(${DYNINST_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,13 @@ add_definitions(-D_GNU_SOURCE)
 # Import the system threads library
 find_package(Threads)
 
-find_package(Dyninst REQUIRED COMPONENTS symtabAPI dyninstAPI pcontrol instructionAPI)
+set(_dyn_libs symtabAPI dyninstAPI pcontrol instructionAPI)
+find_package(Dyninst REQUIRED COMPONENTS ${_dyn_libs})
+
+foreach(l ${_dyn_libs})
+	add_library(${l} INTERFACE IMPORTED)
+	target_link_libraries(${l} INTERFACE Dyninst::${l})
+endforeach()
 
 message(STATUS "Dyninst includes: ${DYNINST_INCLUDE_DIR}")
 include_directories(${DYNINST_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ list(INSERT CMAKE_MODULE_PATH 0
     "${PROJECT_SOURCE_DIR}/cmake/Modules"
     "${Dyninst_DIR}"
     "${Dyninst_DIR}/tpls"
+    "${Dyninst_DIR}/Modules"
     )
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -49,19 +50,10 @@ find_package(Threads)
 
 # Read the cache generated from building Dyninst
 load_cache(${Dyninst_DIR}
-           ElfUtils_INCLUDE_DIRS
-           ElfUtils_LIBRARY_DIRS
            STERILE_BUILD
            USE_GNU_DEMANGLER
            LibIberty_LIBRARY_DIRS
            )
-
-# Import the include and library directory names
-# NB: ElfUtils is not (currently) used directly in
-#     Testsuite, but is transitively included from headers
-#     in Dyninst.
-include_directories(${ElfUtils_INCLUDE_DIRS})
-link_directories(${ElfUtils_LIBRARY_DIRS})
 
 if(NOT ${USE_GNU_DEMANGLER})
 	link_directories(${LibIberty_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ set(Dyninst_DIR ${_dyninst_dir} CACHE PATH "Location of Dyninst cmake files")
 list(INSERT CMAKE_MODULE_PATH 0
     "${PROJECT_SOURCE_DIR}/cmake"
     "${PROJECT_SOURCE_DIR}/cmake/Modules"
-    "${Dyninst_DIR}")
+    "${Dyninst_DIR}"
+    "${Dyninst_DIR}/tpls"
+    )
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -47,9 +49,6 @@ find_package(Threads)
 
 # Read the cache generated from building Dyninst
 load_cache(${Dyninst_DIR}
-           Boost_INCLUDE_DIRS
-           Boost_LIBRARY_DIRS
-           Boost_DEFINES
            ElfUtils_INCLUDE_DIRS
            ElfUtils_LIBRARY_DIRS
            STERILE_BUILD
@@ -61,10 +60,6 @@ load_cache(${Dyninst_DIR}
 # NB: ElfUtils is not (currently) used directly in
 #     Testsuite, but is transitively included from headers
 #     in Dyninst.
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
-add_definitions(${Boost_DEFINES})
-
 include_directories(${ElfUtils_INCLUDE_DIRS})
 link_directories(${ElfUtils_LIBRARY_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,7 @@ find_package(Threads)
 load_cache(${Dyninst_DIR}
            STERILE_BUILD
            USE_GNU_DEMANGLER
-           LibIberty_LIBRARY_DIRS
            )
-
-if(NOT ${USE_GNU_DEMANGLER})
-	link_directories(${LibIberty_LIBRARY_DIRS})
-endif()
 
 find_package(Dyninst REQUIRED
              COMPONENTS common

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,6 @@ add_definitions(-D_GNU_SOURCE)
 # Import the system threads library
 find_package(Threads)
 
-# Read the cache generated from building Dyninst
-load_cache(${Dyninst_DIR}
-           STERILE_BUILD
-           USE_GNU_DEMANGLER
-           )
-
 find_package(Dyninst REQUIRED
              COMPONENTS common
              OPTIONAL_COMPONENTS symtabAPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,27 +7,9 @@ endif()
 
 project(Dyninst-TestSuite)
 
-# User must provide location of Dyninst cmake files either as a cache or
-# environment variable
-if(NOT Dyninst_DIR)
-  if("$ENV{Dyninst_DIR}" STREQUAL "")
-    message(FATAL_ERROR "Dyninst_DIR not found: define as a cache or environment variable")
-  else()
-    set(_dyninst_dir ENV{Dyninst_DIR})
-  endif()
-else()
-  set(_dyninst_dir ${Dyninst_DIR})
-  set(ENV{Dyninst_DIR} ${_dyninst_dir})
-endif()
-
-set(Dyninst_DIR ${_dyninst_dir} CACHE PATH "Location of Dyninst cmake files")
-
 list(INSERT CMAKE_MODULE_PATH 0
     "${PROJECT_SOURCE_DIR}/cmake"
     "${PROJECT_SOURCE_DIR}/cmake/Modules"
-    "${Dyninst_DIR}"
-    "${Dyninst_DIR}/tpls"
-    "${Dyninst_DIR}/Modules"
     )
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ add_definitions(-D_GNU_SOURCE)
 find_package(Threads)
 
 set(_dyn_libs symtabAPI dyninstAPI pcontrol instructionAPI dyninstAPI_RT dyninstAPI_RT_static)
-find_package(Dyninst REQUIRED COMPONENTS ${_dyn_libs})
+find_package(Dyninst 12.3.0 REQUIRED COMPONENTS ${_dyn_libs})
 
 # Make the aliases for the old-style targets
 #  The mutatees don't support the new style

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,11 @@ include_directories(${DYNINST_INCLUDE_DIR})
 message(STATUS "Project source dir: ${PROJECT_SOURCE_DIR}")
 set(BUILD_SHARED_LIBS ON)
 
-set(INSTALL_DIR "bin/testsuite" CACHE PATH "Testsuite installation directory")
+if(CMAKE_INSTALL_PREFIX)
+  set(INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
+else()
+  set(INSTALL_DIR "bin/testsuite" CACHE PATH "Testsuite installation directory")
+endif()
 
 # Build rules for the test libraries (libtestdyninst, libtestproccontrol, etc.)
 # and the executables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-# CMake tries to auto-add flags to link lines, which isn't helpful.  Blanking
-# this variable should fix.
-set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
-set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
-
 include(LanguageStandards)
 include(optimization)
 

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -57,7 +57,7 @@ sub configure {
 			  . "-DCMAKE_INSTALL_PREFIX=$base_dir/tests "
 			  . "$args->{'cmake-args'} "
 			  . "$args->{'testsuite-cmake-args'} "
-			  . "-DDyninst_DIR=../dyninst/lib/cmake/Dyninst "
+			  . "-DDyninst_DIR=\$PWD/../dyninst/lib/cmake/Dyninst "
 			  . "1>config.out 2>config.err");
 	};
 	die "Error configuring: see $build_dir/config.err for details" if $@;

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -148,7 +148,7 @@ sub run_tests {
 	my ($args, $base_dir, $run_log) = @_;
 
 	# Grab the paths in the Dyninst build cache
-	my @lib_dirs = ('Boost_LIBRARY_DIRS', 'TBB_LIBRARY_DIRS', 'ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
+	my @lib_dirs = ('Boost_LIBRARY_DIRS', 'ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
 	my $cache    = "$args->{'dyninst-cmake-cache-dir'}/CMakeCache.txt";
 	my @libs     = load_from_cache($cache, \@lib_dirs);
 

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -148,7 +148,7 @@ sub run_tests {
 	my ($args, $base_dir, $run_log) = @_;
 
 	# Grab the paths in the Dyninst build cache
-	my @lib_dirs = ('Boost_LIBRARY_DIRS', 'ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
+	my @lib_dirs = ('ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
 	my $cache    = "$args->{'dyninst-cmake-cache-dir'}/CMakeCache.txt";
 	my @libs     = load_from_cache($cache, \@lib_dirs);
 

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -54,10 +54,9 @@ sub configure {
 		execute("cd $build_dir\n"
 			  . "$args->{'cmake'} "
 			  . "../src "
-			  . "-DCMAKE_INSTALL_PREFIX=$base_dir "
+			  . "-DCMAKE_INSTALL_PREFIX=$base_dir/tests "
 			  . "$args->{'cmake-args'} "
 			  . "$args->{'testsuite-cmake-args'} "
-			  . "-DINSTALL_DIR=$base_dir/tests "
 			  . "-DDyninst_DIR=../dyninst/lib/cmake/Dyninst "
 			  . "1>config.out 2>config.err");
 	};

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -147,13 +147,7 @@ sub _run_single {
 sub run_tests {
 	my ($args, $base_dir, $run_log) = @_;
 
-	# Grab the paths in the Dyninst build cache
-	my @lib_dirs = ('LibIberty_LIBRARY_DIRS');
-	my $cache    = "$args->{'dyninst-cmake-cache-dir'}/CMakeCache.txt";
-	my @libs     = load_from_cache($cache, \@lib_dirs);
-
-	push @libs, ($base_dir, realpath("$base_dir/../dyninst/lib"));
-	my $paths = join(':', list_unique(@libs));
+	my $paths = realpath("$base_dir/../dyninst/lib");
 
 	# If user explicitly requests single-stepping, then only run that mode
 	if ($args->{'single-stepping'}) {

--- a/scripts/build/Dyninst/testsuite.pm
+++ b/scripts/build/Dyninst/testsuite.pm
@@ -148,7 +148,7 @@ sub run_tests {
 	my ($args, $base_dir, $run_log) = @_;
 
 	# Grab the paths in the Dyninst build cache
-	my @lib_dirs = ('ElfUtils_LIBRARY_DIRS', 'LibIberty_LIBRARY_DIRS');
+	my @lib_dirs = ('LibIberty_LIBRARY_DIRS');
 	my $cache    = "$args->{'dyninst-cmake-cache-dir'}/CMakeCache.txt";
 	my @libs     = load_from_cache($cache, \@lib_dirs);
 


### PR DESCRIPTION
Dyninst needs to be built with `LIGHTWEIGHT_SYMTAB=OFF` because the symtabAPI tests are now unconditional.