### PR TITLE
Remove -Werror from imported CMAKE_<lang>_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ if(NOT ${USE_GNU_DEMANGLER})
 	link_directories(${LibIberty_LIBRARY_DIRS})
 endif()
 
+foreach(l "C" "CXX")
+  list(FILTER CMAKE_${l}_FLAGS EXCLUDE REGEX "Werror")
+endforeach()
+
 find_package(Dyninst REQUIRED
              COMPONENTS common
              OPTIONAL_COMPONENTS symtabAPI


### PR DESCRIPTION
The test suite doesn't build cleanly yet, so disable Werror. This is needed to make the updated Dyninst CI work correctly.