### PR TITLE
Fix thread safety issues on threading tests

### DIFF
--- a/src/dyninst/test_callback_1_mutatee.c
+++ b/src/dyninst/test_callback_1_mutatee.c
@@ -47,7 +47,7 @@
  * group.
  */
 
-static int mutateeIdle = 0;
+static volatile int mutateeIdle = 0;
 
 /* Function definitions follow */
 

--- a/src/dyninst/test_thread_1_mutatee.c
+++ b/src/dyninst/test_thread_1_mutatee.c
@@ -94,7 +94,7 @@ void register_my_lock(unsigned long id, unsigned int val)
     logerror("%s[%d]: FIXME\n", __FILE__, __LINE__);
 }
 
-int done_threads = 0;
+volatile int done_threads = 0;
 
 int all_threads_done()
 {

--- a/src/dyninst/test_thread_2_mutatee.c
+++ b/src/dyninst/test_thread_2_mutatee.c
@@ -53,7 +53,7 @@
 
 Thread_t test3_threads[TEST3_THREADS];
 Lock_t test3lock;
-int mutateeIdle = 0;
+volatile int mutateeIdle = 0;
 
 /* Function definitions follow */
 


### PR DESCRIPTION
Use volatile on cross-thread/process variables to fix typical thread safety problems 
with the remaining thread0oriented parts of the testsuite.

This makes all threading type tests have the same level of volatile ... until we find more problems.

This Resolves #225 