### PR TITLE
Replace incorrect use of volatile with atomics

### DIFF
--- a/src/atomic.h
+++ b/src/atomic.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined __cplusplus
+#  include <atomic>
+#  define testsuite_atomic(T, name, value) static std::atomic<T> name{value};
+#else
+#  include <stdatomic.h>
+#  define testsuite_atomic(T, name, value) _Atomic T name = value;
+#endif

--- a/src/dyninst/test_thread_1_mutatee.c
+++ b/src/dyninst/test_thread_1_mutatee.c
@@ -40,6 +40,7 @@
 #include "test_thread.h"
 #include "test12.h"
 #include "dyninstRTExport.h"
+#include "atomic.h"
 
 /* Externally accessed function prototypes.  These must have globally unique
  * names.  I suggest following the pattern <testname>_<function>
@@ -94,7 +95,7 @@ void register_my_lock(unsigned long id, unsigned int val)
     logerror("%s[%d]: FIXME\n", __FILE__, __LINE__);
 }
 
-volatile int done_threads = 0;
+testsuite_atomic(int, done_threads, 0)
 
 int all_threads_done()
 {

--- a/src/dyninst/test_thread_2_mutatee.c
+++ b/src/dyninst/test_thread_2_mutatee.c
@@ -33,6 +33,7 @@
 #include "solo_mutatee_boilerplate.h"
 #include "test_thread.h"
 #include "test12.h"
+#include "atomic.h"
 
 /* Externally accessed function prototypes.  These must have globally unique
  * names.  I suggest following the pattern <testname>_<function>
@@ -53,7 +54,7 @@
 
 Thread_t test3_threads[TEST3_THREADS];
 Lock_t test3lock;
-volatile int mutateeIdle = 0;
+testsuite_atomic(int, mutateeIdle, 0)
 
 /* Function definitions follow */
 

--- a/src/dyninst/test_thread_3_mutatee.c
+++ b/src/dyninst/test_thread_3_mutatee.c
@@ -33,6 +33,7 @@
 #include "solo_mutatee_boilerplate.h"
 #include "test_thread.h"
 #include "test12.h"
+#include "atomic.h"
 
 /* Externally accessed function prototypes.  These must have globally unique
  * names.  I suggest following the pattern <testname>_<function>
@@ -53,7 +54,7 @@
 
 Thread_t test4_threads[TEST3_THREADS];
 Lock_t test4lock;
-volatile int mutateeIdle = 0;
+testsuite_atomic(int, mutateeIdle, 0)
 
 /* Function definitions follow */
 

--- a/src/dyninst/test_thread_5_mutatee.c
+++ b/src/dyninst/test_thread_5_mutatee.c
@@ -34,6 +34,8 @@
 #include "test_thread.h"
 #include "test12.h"
 #include <sys/syscall.h>
+#include "atomic.h"
+
 /* Externally accessed function prototypes.  These must have globally unique
  * names.  I suggest following the pattern <testname>_<function>
  */
@@ -42,7 +44,7 @@
  * names.
  */
 
-volatile int test_thread_5_idle = 0;
+testsuite_atomic(int, test_thread_5_idle, 0)
 
 /* Internally used function prototypes.  These should be declared with the
  * keyword static so they don't interfere with other mutatees in the group.

--- a/src/dyninst/test_thread_6_mutatee.c
+++ b/src/dyninst/test_thread_6_mutatee.c
@@ -30,6 +30,7 @@
 
 #include "mutatee_util.h"
 #include "solo_mutatee_boilerplate.h"
+#include "atomic.h"
 
 // This is modified by the mutator
 volatile int proc_current_state = 0;
@@ -42,7 +43,7 @@ volatile int proc_current_state = 0;
  * is enough to prevent the compiler from removing the check
  * in 'init_func'
 */
-volatile int done = 0;
+testsuite_atomic(int, done, 0)
 
 // Barrier to synchronize thread startup
 testbarrier_t startup_barrier;

--- a/src/dyninst/test_thread_7_mutatee.c
+++ b/src/dyninst/test_thread_7_mutatee.c
@@ -36,6 +36,7 @@
 
 #include "mutatee_util.h"
 #include "solo_mutatee_boilerplate.h"
+#include "atomic.h"
 
 extern thread_t spawnNewThread(void *initial_func, void *param);
 extern void* joinThread(thread_t threadid);
@@ -58,7 +59,7 @@ volatile int threads_running[NTHRD];
 testlock_t barrier_mutex;
 testlock_t count_mutex;
 
-volatile int times_level1_called;
+testsuite_atomic(int, times_level1_called, 0)
 
 void my_barrier(volatile int *br)
 {
@@ -210,7 +211,7 @@ int test_thread_7_mutatee() {
    if (times_level1_called != NTHRD*N_INSTR)
    {
       logerror("[%s:%u] - level1 called %u times.  Expected %u\n",
-              __FILE__, __LINE__, times_level1_called, NTHRD*N_INSTR);
+              __FILE__, __LINE__, +times_level1_called, NTHRD*N_INSTR);
       return -1;
    }
 

--- a/src/dyninst/test_thread_8_mutatee.c
+++ b/src/dyninst/test_thread_8_mutatee.c
@@ -36,6 +36,7 @@
 #include <limits.h>
 #include "mutatee_util.h"
 #include "solo_mutatee_boilerplate.h"
+#include "atomic.h"
 
 #define NTHRD 5
 thread_t thrds[NTHRD];
@@ -48,9 +49,9 @@ volatile int threads_running[NTHRD];
 void check_sync();
 void check_async();
 
-volatile int sync_failure = 0;
-volatile int async_failure = 0;
-volatile int timeout_failure = 0;
+testsuite_atomic(int, sync_failure, 0)
+testsuite_atomic(int, async_failure, 0)
+testsuite_atomic(int, timeout_failure, 0)
 
 volatile unsigned thr_exits;
 
@@ -186,10 +187,10 @@ int test_thread_8_mutatee() {
    
    if(sync_failure)
       logerror("%s[%d]: ERROR: oneTimeCode failed for %d threads\n", 
-              __FILE__, __LINE__, sync_failure);
+              __FILE__, __LINE__, +sync_failure);
    if(async_failure)
       logerror("%s[%d]: ERROR: oneTimeCodeAsync failed for %d threads\n", 
-              __FILE__, __LINE__, async_failure);
+              __FILE__, __LINE__, +async_failure);
 
    /* TODO Check return value for this mutatee! */
    if(sync_failure) return -1;

--- a/src/mutatee_driver.c
+++ b/src/mutatee_driver.c
@@ -38,6 +38,7 @@
 #include <ctype.h>
 #include <assert.h>
 #include <errno.h>
+#include <atomic.h>
 
 #if defined(os_windows_test)
 #define WIN32_LEAN_AND_MEAN
@@ -66,7 +67,7 @@ extern "C" {
 }
 #endif
 
-volatile int isAttached = 0;
+testsuite_atomic(int, isAttached, 0)
 
 #include "mutatee_call_info.h"
 /* #include "mutatee_glue.h" */


### PR DESCRIPTION
There are many places where volatile is used in an attempt to synchronize data writes across threads. This is never guaranteed to work. Replacing these uses with the C11 _Atomic or the C++11 std::atomic<t> provides the correct behavior.

Using unary plus in the debug messages is a bit of a hack, but it's the easiest way of getting a 'load' in both C and C++ without resorting to more macro trickery.