### PR TITLE
Replace usage of deprecated boost/filesystem/convenience.hpp

### DIFF
--- a/src/symtab/test_type_info.C
+++ b/src/symtab/test_type_info.C
@@ -38,7 +38,7 @@
 #include <array>
 #include <functional>
 #include <iostream>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/path.hpp>
 
 using namespace Dyninst;
 using namespace SymtabAPI;


### PR DESCRIPTION
It was removed in v1.85.0.