### PR TITLE
Fix possible double-free in CFT tests

### DIFF
--- a/src/instruction/aarch64_cft.C
+++ b/src/instruction/aarch64_cft.C
@@ -199,7 +199,9 @@ test_results_t aarch64_cft_Mutator::executeTest()
               logerror("FAILED: instruction %s expected CFT, wasn't present", decodedInsns.front().format().c_str());
               retVal = failure_accumulator(retVal, FAILED);
           }
-          cfts.pop_front();
+          if(!cfts.empty()) {
+            cfts.pop_front();
+          }
       }
 
       decodedInsns.pop_front();

--- a/src/instruction/power_cft.C
+++ b/src/instruction/power_cft.C
@@ -180,7 +180,9 @@ test_results_t power_cft_Mutator::executeTest()
               logerror("FAILED: instruction %s expected CFT, wasn't present", decodedInsns.front().format().c_str());
               retVal = failure_accumulator(retVal, FAILED);
           }
-          cfts.pop_front();
+          if(!cfts.empty()) {
+            cfts.pop_front();
+          }
       }
       
       decodedInsns.pop_front();


### PR DESCRIPTION
In the event there are more operands than test results, the test should fail, not crash.