### PR TITLE
Convert some asserts into failure checks

### DIFF
--- a/src/dyninst/snip_ref_shlib_var.C
+++ b/src/dyninst/snip_ref_shlib_var.C
@@ -94,7 +94,6 @@ BPatch_snippet * snip_ref_shlib_var_Mutator::doVarAssign(const char *to, const c
 
 	BPatch_snippet *ret;
 	ret = new BPatch_arithExpr(BPatch_assign, *to_v, *from_v);
-	assert(ret);
 	return ret;
 }
 
@@ -120,7 +119,6 @@ BPatch_snippet * snip_ref_shlib_var_Mutator::doVarArrayAssign(
     BPatch_snippet *ret;
     ret = new BPatch_arithExpr(BPatch_assign,
            BPatch_arithExpr(BPatch_ref, *to_v, BPatch_constExpr(idx)), *from_v);
-    assert(ret);
 	return ret;
 }
 

--- a/src/dyninst/test5_4.C
+++ b/src/dyninst/test5_4.C
@@ -67,12 +67,21 @@ test_results_t test5_4_Mutator::executeTest() {
     logerror("    Unable to find function %s\n", fn);
     return FAILED;
   }
-  BPatch_function *f1 = bpfv[0];  
-  BPatch_Vector<BPatch_point *> *point4_1 = f1->findPoint(BPatch_subroutine);
-  BPatch_Vector<BPatch_point *> *point4_3 = f1->findPoint(BPatch_exit);
-  assert(point4_3);
-  assert(point4_1);
-  
+  BPatch_function *f1 = bpfv[0];
+  BPatch_Vector<BPatch_point*> *point4_1 = f1->findPoint(BPatch_subroutine);
+  if(!point4_1) {
+    logerror("**Failed** test #4 (static member)\n");
+    logerror("Didn't find subroutine point for 'static_test::func_cpp'\n");
+    return FAILED;
+  }
+
+  BPatch_Vector<BPatch_point*> *point4_3 = f1->findPoint(BPatch_exit);
+  if(!point4_3) {
+    logerror("**Failed** test #4 (static member)\n");
+    logerror("Didn't find exit point for 'static_test::func_cpp'\n");
+    return FAILED;
+  }
+
   int index = 0;
   BPatch_function *func;
   int bound = point4_1->size();
@@ -91,10 +100,13 @@ test_results_t test5_4_Mutator::executeTest() {
     }
     else if (!strcmp("static_test::call_cpp", func->getName(fn, 256))) {
       found_func = true;
-      BPatch_Vector<BPatch_point *> *point4_2 = func->findPoint(BPatch_exit);
-      assert(point4_2);
-      assert(!point4_2->empty());
-      
+      BPatch_Vector<BPatch_point*> *point4_2 = func->findPoint(BPatch_exit);
+      if(!point4_2 || point4_2->empty()) {
+        logerror("**Failed** test #4 (static member)\n");
+        logerror("Didn't find exit point for 'static_test::call_cpp'\n");
+        return FAILED;
+      }
+
       // use getComponent to access this "count". However, getComponent is
       // causing core dump at this point
       BPatch_variableExpr *var4_1 = appImage->findVariable(*(*point4_2)[0],

--- a/src/dyninst/test_callback_1.C
+++ b/src/dyninst/test_callback_1.C
@@ -82,8 +82,6 @@ static void dynSiteCB(BPatch_point *dyn_site, BPatch_function *called_function)
   //  static int counter2 = 0;
   BPatch_point *pt = dyn_site;
   BPatch_function *func = called_function;
-  assert(pt);
-  assert(func);
 
   void *callsite_addr = pt->getAddress();
   dprintf("%s[%d]:  callsite addr = %p\n", __FILE__, __LINE__, callsite_addr);

--- a/src/dyninst/test_callback_2.C
+++ b/src/dyninst/test_callback_2.C
@@ -81,7 +81,12 @@ std::vector<user_msg_t> elog;
 static BPatch_point *findPoint(BPatch_function *f, BPatch_procedureLocation loc,
                         int testno, const char *testname)
 {
-  assert(f);
+  if(!f) {
+    logerror("%s[%d]: Invaild BPatch_function\n", FILE__, __LINE__);
+    FAIL_MES(TESTNAME, TESTDESC);
+    return NULL;
+  }
+
   BPatch_Vector<BPatch_point *> *pts = f->findPoint(loc);
 
   if (!pts) {
@@ -112,7 +117,12 @@ test_callback_2_Mutator::at(BPatch_point * pt, BPatch_function *call,
   if (pttype == BPatch_entry) when = BPatch_callBefore;
   else if (pttype == BPatch_exit) when = BPatch_callAfter;
   else if (pttype == BPatch_subroutine) when = BPatch_callBefore;
-  else assert(0);
+  else {
+    logerror("%s[%d]: Unknown point type: '%d'\n", __FILE__, __LINE__, pttype);
+    FAIL_MES(TESTNAME, TESTDESC);
+    test7err = true;
+    return nullptr;
+  }
 
   BPatchSnippetHandle *ret;
   ret = appProc->insertSnippet(snip, *pt,when);


### PR DESCRIPTION
It's confusing to have the mutator crash when there isn't an actual internal Dyninst error.

This is only a tiny fraction of the number of these present, but they are the ones I've recently encountered.