### PR TITLE
Fix, update, and extend instruction decoding and CFT tests

### DIFF
--- a/src/instruction/aarch64_decode.C
+++ b/src/instruction/aarch64_decode.C
@@ -28,41 +28,36 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "instruction_comp.h"
-#include "test_lib.h"
-
 #include "Instruction.h"
+#include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
 #include "registers/aarch64_regs.h"
+#include "test_lib.h"
 
-#include <boost/assign/list_of.hpp>
-#include <boost/iterator/indirect_iterator.hpp>
-
-#include <deque>
 #include <array>
-#include <vector>
-#include <algorithm>
+#include <boost/range/combine.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <deque>
 
 using namespace Dyninst;
 using namespace InstructionAPI;
 
-class aarch64_decode_Mutator: public InstructionMutator {
-private:
-  void setupRegisters();
+class aarch64_decode_Mutator : public InstructionMutator {
 public:
   aarch64_decode_Mutator() {}
-  virtual test_results_t executeTest();
+
+  virtual test_results_t executeTest() override;
 };
 
 extern "C" DLLEXPORT TestMutator* aarch64_decode_factory() {
   return new aarch64_decode_Mutator();
 }
 
-static void reverseBuffer(unsigned char *buffer, int bufferSize) {
+static void reverseBuffer(unsigned char* buffer, int bufferSize) {
   int elementCount = bufferSize / 4;
 
-  for (int loop_index = 0; loop_index < elementCount; loop_index++) {
+  for(int loop_index = 0; loop_index < elementCount; loop_index++) {
     std::swap(buffer[0], buffer[3]);
     std::swap(buffer[1], buffer[2]);
     buffer += 4;
@@ -72,460 +67,466 @@ static void reverseBuffer(unsigned char *buffer, int bufferSize) {
 test_results_t aarch64_decode_Mutator::executeTest() {
   constexpr auto num_tests = 120;
 
-  std::array<unsigned char, 4*num_tests> buffer = {
-    0x0B, 0x0C, 0x01, 0x41,		// ADD W1, W10, W12
-    0x0B, 0x08, 0x14, 0xA0,		// ADD W0, W5, W8, LSL #5
-    0x8B, 0x49, 0x28, 0xE4,		// ADD X4, X7, X9, LSR #10
-    0x4B, 0x04, 0x00, 0x40,		// SUB W0, W2, W4
-    0xCB, 0x8B, 0x1D, 0x06,		// SUB X6, X8, X11, ASR #7
-    0x2B, 0x08, 0x14, 0xA0,		// ADDS W0, W5, W8, LSL #5
-    0x0B, 0x2F, 0x69, 0x45,		// ADD W5, W10, W15
-    0xCB, 0x21, 0x80, 0x20,		// SUB X0, X1, X1, UXTB #0
-    0xEB, 0x22, 0x70, 0x42,		// SUBS X2, X2, X2, SXTW #4
-    0x1A, 0x19, 0x02, 0xC5,		// ADC W5, W22, W25
-    0xDA, 0x02, 0x00, 0x20,		// SBC X0, X1, X2
-    0x3A, 0x5E, 0x58, 0xEB,		// CCMN W7, #30, #11, 5
-    0xFA, 0x48, 0xFA, 0x88,		// CCMP X20, #8, #0, 15
-    0x3A, 0x4A, 0x10, 0xA7,		// CCMN W5, W10, #7, 1
-    0xFA, 0x42, 0xA0, 0x84,		// CCMP X2, X4, #4, 10
-    0x1A, 0x8F, 0x11, 0x45,		// CSEL W5, W10, W15, 1
-    0x9A, 0x84, 0x54, 0x40, 	// CSINC X0, X2, X4, 5
-    0xDA, 0x96, 0x72, 0xB4,		// CSINV X20, X21, X22, 7
-    0x5A, 0x8A, 0xA4, 0xA1,		// CSNEG W1, W5, W9, 10
-    0x5A, 0xC0, 0x00, 0x41,		// RBIT W1, W2
-    0xDA, 0xC0, 0x0E, 0x8A,		// REV X10, X20
-    0x5A, 0xC0, 0x13, 0xBE,		// CLZ W30, W29
-    0xDA, 0xC0, 0x15, 0x8B,		// CLS X11, X12
-    0x5A, 0xC0, 0x05, 0x80,		// REV16 W0, W12
-    0x1A, 0xC4, 0x08, 0x40,		// UDIV W0, W2, W4
-    0x9A, 0xD9, 0x0E, 0x8F,		// SDIV X15, X20, X25
-    0x1A, 0xCB, 0x21, 0x05,		// LSLV W5, W8, W11
-    0x9A, 0xCB, 0x29, 0x27,		// ASRV X7, X9, X11
-    0x1A, 0xC4, 0x2C, 0x10,		// RORV W16, W0, W4
-    0x1B, 0x02, 0x00, 0x61,		// MADD W1, W3, W2, W0
-    0x9B, 0x10, 0xF9, 0x04,		// MSUB X4, X8, X16, X30
-    0x9B, 0x21, 0x84, 0x00,		// SMSUBL X0, X0, X1, X1
-    0x9B, 0xCA, 0x28, 0xA5,		// UMULH W5, W5, W10, W10
-    0x0A, 0x03, 0x00, 0x41,		// AND W1, W2, W3
-    0x8A, 0x2A, 0x14, 0xA0,		// BIC X0, X5, X10, LSL #5
-    0x2A, 0x62, 0x28, 0x00,		// ORN W0, W0, W2, LSR #10
-    0xCA, 0x96, 0x0A, 0xB4,		// EOR X20, X21, X22, ASR #2
-    0xEA, 0xE1, 0x20, 0x21,		// BICS X1, X1, X1, ROR #8
-    0x11, 0x00, 0x2F, 0xE0,		// ADD W0, WSP, #11
-    0x31, 0x40, 0x01, 0x45,		// ADDS W5, W10, #0, LSL #12
-    0xD1, 0x40, 0x31, 0x5F,		// SUB SP, X10, #12
-    0x13, 0x19, 0x29, 0xCC,		// SBFM W12, W14, #25, #10
-    0xB3, 0x40, 0x07, 0xC0,		// BFM X0, X30, #63, #0
-    0xD3, 0x41, 0x20, 0x14,		// UBFM X20, X0, #8, #1
-    0x13, 0x9E, 0x16, 0x8A,		// EXTR W10, W20, W30, #5
-    0x93, 0xD0, 0xFD, 0x00,		// EXTR X0, X8, X16, #63
-    0x12, 0x2A, 0x1F, 0x1F,		// AND WSP, W24, #63
-    0xB2, 0x00, 0x03, 0xDF,		// ORR SP, X30, #0
-    0xD2, 0x7F, 0xAF, 0x34,		// EOR X20, X25, #
-    0x72, 0x00, 0x25, 0x45,		// ANDS W5, W10, #9
-    0x12, 0xA0, 0x02, 0xE4,		// MOVN W4, #23, LSL #1
-    0xD2, 0xC0, 0x02, 0x54,		// MOVZ X20, #18, LSL #2
-    0xF2, 0xE0, 0x20, 0x01,		// MOVK X1, #256, LSL #3
-    0x12, 0x80, 0x01, 0x08,		// MOVN W8, #8
-    0x10, 0x80, 0x00, 0x00,		// ADR X0, #
-    0xF0, 0x00, 0x00, 0x3E,		// ADRP X30, #7
-    0x34, 0xFF, 0xFF, 0xEF,		// CBZ W15, #
-    0xB5, 0x00, 0x00, 0x3E,		// CBNZ X30, #1
-    0x54, 0xFF, 0xFF, 0xE1,		// B.NE #
-    0x54, 0x00, 0x07, 0xEC,		// B.GT #63
-    0x36, 0xF7, 0xFF, 0xE4,		// TBZ W4, #30, #
-    0xB7, 0x80, 0x00, 0x19,		// TBNZ X25, #0, #16
-    0x37, 0x60, 0x01, 0x9F,		// TBNZ WZR, #9, #12
-    0x17, 0xFF, 0xFF, 0xFF,		// B #
-    0x94, 0x00, 0x00, 0x08,		// BL #8
-    0xD6, 0x1F, 0x01, 0x80,		// BR X12
-    0xD6, 0x3F, 0x03, 0xC0,		// BLR X30
-    0xD6, 0x5F, 0x00, 0x00,		// RET X0
-    0x1E, 0x3F, 0x20, 0x00,		// FCMP S0, S31
-    0x1E, 0x30, 0x21, 0x08,		// FCMP D16, #0.0
-    0x1E, 0x7F, 0x23, 0xC0,		// FCMP D31, D32
-    0x1E, 0x3F, 0xA6, 0x88,		// FCCMP S20, S31, #8, 10
-    0x1E, 0x62, 0x04, 0x25,		// FCCMP D1, D2, #5, 0
-    0x1E, 0x6B, 0x55, 0x59,		// FCCMPE D10, D1,, #9, 5
-    0x1E, 0x23, 0x4C, 0x41,		// FCSEL S1, S, S3, 4
-    0x1E, 0x20, 0x41, 0x45,		// FMOV S5, S10
-    0x1E, 0x60, 0xC3, 0xFF,		// FABS D30, D31
-    0x1E, 0x64, 0xC0, 0x40,		// FRINTP D0, D2
-    0x1E, 0xE2, 0x40, 0xA4,		// FCVT S4, H5
-    0x1E, 0xE2, 0xC3, 0xE0,		// FCVT D0, H31
-    0x1E, 0x22, 0xC0, 0x02,		// FCVT D2, S0
-    0x1E, 0x63, 0xC3, 0xFF,		// FCVT H31, D31
-    0x1E, 0x62, 0x40, 0x21,		// FCVT S1, D1
-    0x1E, 0x23, 0xC2, 0x08,		// FCVT H8, S16
-    0x1E, 0x22, 0x08, 0x20,		// FMUL S0, S1, S2
-    0x1E, 0x7F, 0x3B, 0xDD,		// FSUB D29, D30, D31
-    0x1E, 0x6F, 0x19, 0x45,		// FDIV D5, D10, D15
-    0x1E, 0x20, 0x4A, 0x08,		// FMAX S8, S16, S0
-    0x1E, 0x21, 0x78, 0x21,		// FNINNM S1, S1, S1
-    0x1F, 0x02, 0x0C, 0x20,		// FMADD S0, S1, S2, S3
-    0x1F, 0x48, 0xC0, 0x82,		// FMSUB D2, D4, D8, D16
-    0x1F, 0x2B, 0x35, 0x6A,		// FNMADD S10, S11, S11, S13
-    0x1F, 0x62, 0x84, 0x88,		// FNMSUB D8, D4, D2, D1
-    0x1E, 0x31, 0x10, 0x00,		// FMOV S0, #88
-    0x1E, 0x67, 0xF0, 0x1F,		// FMOV D31, #7F
-    0x1E, 0x02, 0x97, 0xC0,		// SCVTF S0, W30, #59
-    0x9E, 0x43, 0x24, 0x01,		// UCVTF D1, X0, #55
-    0x1E, 0x02, 0xC1, 0x45,		// SCVTF S5, W10, #64
-    0x1E, 0x43, 0x84, 0x48,		// UCVTF D8, W2, #63
-    0x1E, 0x19, 0xC4, 0x0B,		// FCVTZU W12, S0, #63
-    0x9E, 0x58, 0xFF, 0xFE,		// FCVTZS X30, D31, #0
-    0x9E, 0x19, 0xE1, 0x41,		// FCVTZU X1, S10, #8
-    0x1E, 0x58, 0xF1, 0x29,		// FCVTZS W9, D9, #4
-    0x1E, 0x20, 0x00, 0xA8,		// FCVTNS W8, S5
-    0x1E, 0x27, 0x03, 0xC1,		// FMOV S1, W30
-    0xD4, 0x10, 0x00, 0x01,		// SVC #32768
-    0xD4, 0x00, 0x00, 0x03, 	// SMC #0
-    0xD4, 0x40, 0x03, 0xC0,		// HLT #30
-    0xD4, 0xA0, 0x00, 0x42,		// DCPS2 #2
-    0xD5, 0x03, 0x30, 0x5F,		// CLREX
-    0xD5, 0x03, 0x34, 0x9F,		// DSB #4
-    0xD5, 0x03, 0x31, 0xBF,		// DMB #1
-    0xD5, 0x03, 0x20, 0xBF,		// HINT #5
-    0xD5, 0x03, 0x45, 0xDF,		// MSR 30, #5
-    0xD5, 0x09, 0x23, 0x80,		// SYS #1, #2, #3, #4, X0
-    0xD5, 0x29, 0x23, 0x9E,		// SYSL #1, #2, #3, #4, X30
-    0xD5, 0x3B, 0x9C, 0xC1,		// MRS X1, PMCEID0_EL0
-    0xD5, 0x3B, 0xE8, 0x40,		// MRS X0, PMEVCNTR2_EL0
-    0xD5, 0x1B, 0xE0, 0x21,		// MSR CNTPCT_EL0, X1
-    0xD5, 0x1B, 0xEF, 0xC0,		// MSR PMEVTYPER30_EL0, X0
+  // clang-format off
+  std::array<uint8_t, 4*num_tests> buffer = {
+    0x0b, 0x0c, 0x01, 0x41,   // add w1, w10, w12
+    0x0b, 0x08, 0x14, 0xa0,   // add w0, w5, w8, lsl #5
+    0x8b, 0x49, 0x28, 0xe4,   // add x4, x7, x9, lsr #10
+    0x4b, 0x04, 0x00, 0x40,   // sub w0, w2, w4
+    0xcb, 0x8b, 0x1d, 0x06,   // sub x6, x8, x11, asr #7
+    0x2b, 0x08, 0x14, 0xa0,   // adds w0, w5, w8, lsl #5
+    0x0b, 0x2f, 0x69, 0x45,   // add w5, w10, w15
+    0xcb, 0x21, 0x80, 0x20,   // sub x0, x1, x1, uxtb #0
+    0xeb, 0x22, 0x70, 0x42,   // subs x2, x2, x2, sxtw #4
+    0x1a, 0x19, 0x02, 0xc5,   // adc w5, w22, w25
+    0xda, 0x02, 0x00, 0x20,   // sbc x0, x1, x2
+    0x3a, 0x5e, 0x58, 0xeb,   // ccmn w7, #30, #11, 5
+    0xfa, 0x48, 0xfa, 0x88,   // ccmp x20, #8, #0, 15
+    0x3a, 0x4a, 0x10, 0xa7,   // ccmn w5, w10, #7, 1
+    0xfa, 0x42, 0xa0, 0x84,   // ccmp x2, x4, #4, 10
+    0x1a, 0x8f, 0x11, 0x45,   // csel w5, w10, w15, 1
+    0x9a, 0x84, 0x54, 0x40,   // csinc x0, x2, x4, 5
+    0xda, 0x96, 0x72, 0xb4,   // csinv x20, x21, x22, 7
+    0x5a, 0x8a, 0xa4, 0xa1,   // csneg w1, w5, w9, 10
+    0x5a, 0xc0, 0x00, 0x41,   // rbit w1, w2
+    0xda, 0xc0, 0x0e, 0x8a,   // rev x10, x20
+    0x5a, 0xc0, 0x13, 0xbe,   // clz w30, w29
+    0xda, 0xc0, 0x15, 0x8b,   // cls x11, x12
+    0x5a, 0xc0, 0x05, 0x80,   // rev16 w0, w12
+    0x1a, 0xc4, 0x08, 0x40,   // udiv w0, w2, w4
+    0x9a, 0xd9, 0x0e, 0x8f,   // sdiv x15, x20, x25
+    0x1a, 0xcb, 0x21, 0x05,   // lslv w5, w8, w11
+    0x9a, 0xcb, 0x29, 0x27,   // asrv x7, x9, x11
+    0x1a, 0xc4, 0x2c, 0x10,   // rorv w16, w0, w4
+    0x1b, 0x02, 0x00, 0x61,   // madd w1, w3, w2, w0
+    0x9b, 0x10, 0xf9, 0x04,   // msub x4, x8, x16, x30
+    0x9b, 0x21, 0x84, 0x00,   // smsubl x0, x0, x1, x1
+    0x9b, 0xca, 0x28, 0xa5,   // umulh w5, w5, w10, w10
+    0x0a, 0x03, 0x00, 0x41,   // and w1, w2, w3
+    0x8a, 0x2a, 0x14, 0xa0,   // bic x0, x5, x10, lsl #5
+    0x2a, 0x62, 0x28, 0x00,   // orn w0, w0, w2, lsr #10
+    0xca, 0x96, 0x0a, 0xb4,   // eor x20, x21, x22, asr #2
+    0xea, 0xe1, 0x20, 0x21,   // bics x1, x1, x1, ror #8
+    0x11, 0x00, 0x2f, 0xe0,   // add w0, wsp, #11
+    0x31, 0x40, 0x01, 0x45,   // adds w5, w10, #0, lsl #12
+    0xd1, 0x40, 0x31, 0x5f,   // sub sp, x10, #12
+    0x13, 0x19, 0x29, 0xcc,   // sbfm w12, w14, #25, #10
+    0xb3, 0x40, 0x07, 0xc0,   // bfm x0, x30, #63, #0
+    0xd3, 0x41, 0x20, 0x14,   // ubfm x20, x0, #8, #1
+    0x13, 0x9e, 0x16, 0x8a,   // extr w10, w20, w30, #5
+    0x93, 0xd0, 0xfd, 0x00,   // extr x0, x8, x16, #63
+    0x12, 0x2a, 0x1f, 0x1f,   // and wsp, w24, #63
+    0xb2, 0x00, 0x03, 0xdf,   // orr sp, x30, #0
+    0xd2, 0x7f, 0xaf, 0x34,   // eor x20, x25, #
+    0x72, 0x00, 0x25, 0x45,   // ands w5, w10, #9
+    0x12, 0xa0, 0x02, 0xe4,   // movn w4, #23, lsl #1
+    0xd2, 0xc0, 0x02, 0x54,   // movz x20, #18, lsl #2
+    0xf2, 0xe0, 0x20, 0x01,   // movk x1, #256, lsl #3
+    0x12, 0x80, 0x01, 0x08,   // movn w8, #8
+    0x10, 0x80, 0x00, 0x00,   // adr x0, #
+    0xf0, 0x00, 0x00, 0x3e,   // adrp x30, #7
+    0x34, 0xff, 0xff, 0xef,   // cbz w15, #
+    0xb5, 0x00, 0x00, 0x3e,   // cbnz x30, #1
+    0x54, 0xff, 0xff, 0xe1,   // b.ne #
+    0x54, 0x00, 0x07, 0xec,   // b.gt #63
+    0x36, 0xf7, 0xff, 0xe4,   // tbz w4, #30, #
+    0xb7, 0x80, 0x00, 0x19,   // tbnz x25, #0, #16
+    0x37, 0x60, 0x01, 0x9f,   // tbnz wzr, #9, #12
+    0x17, 0xff, 0xff, 0xff,   // b #
+    0x94, 0x00, 0x00, 0x08,   // bl #8
+    0xd6, 0x1f, 0x01, 0x80,   // br x12
+    0xd6, 0x3f, 0x03, 0xc0,   // blr x30
+    0xd6, 0x5f, 0x00, 0x00,   // ret x0
+    0x1e, 0x3f, 0x20, 0x00,   // fcmp s0, s31
+    0x1e, 0x30, 0x21, 0x08,   // fcmp d16, #0.0
+    0x1e, 0x7f, 0x23, 0xc0,   // fcmp d31, d32
+    0x1e, 0x3f, 0xa6, 0x88,   // fccmp s20, s31, #8, 10
+    0x1e, 0x62, 0x04, 0x25,   // fccmp d1, d2, #5, 0
+    0x1e, 0x6b, 0x55, 0x59,   // fccmpe d10, d1,, #9, 5
+    0x1e, 0x23, 0x4c, 0x41,   // fcsel s1, s, s3, 4
+    0x1e, 0x20, 0x41, 0x45,   // fmov s5, s10
+    0x1e, 0x60, 0xc3, 0xff,   // fabs d30, d31
+    0x1e, 0x64, 0xc0, 0x40,   // frintp d0, d2
+    0x1e, 0xe2, 0x40, 0xa4,   // fcvt s4, h5
+    0x1e, 0xe2, 0xc3, 0xe0,   // fcvt d0, h31
+    0x1e, 0x22, 0xc0, 0x02,   // fcvt d2, s0
+    0x1e, 0x63, 0xc3, 0xff,   // fcvt h31, d31
+    0x1e, 0x62, 0x40, 0x21,   // fcvt s1, d1
+    0x1e, 0x23, 0xc2, 0x08,   // fcvt h8, s16
+    0x1e, 0x22, 0x08, 0x20,   // fmul s0, s1, s2
+    0x1e, 0x7f, 0x3b, 0xdd,   // fsub d29, d30, d31
+    0x1e, 0x6f, 0x19, 0x45,   // fdiv d5, d10, d15
+    0x1e, 0x20, 0x4a, 0x08,   // fmax s8, s16, s0
+    0x1e, 0x21, 0x78, 0x21,   // fninnm s1, s1, s1
+    0x1f, 0x02, 0x0c, 0x20,   // fmadd s0, s1, s2, s3
+    0x1f, 0x48, 0xc0, 0x82,   // fmsub d2, d4, d8, d16
+    0x1f, 0x2b, 0x35, 0x6a,   // fnmadd s10, s11, s11, s13
+    0x1f, 0x62, 0x84, 0x88,   // fnmsub d8, d4, d2, d1
+    0x1e, 0x31, 0x10, 0x00,   // fmov s0, #88
+    0x1e, 0x67, 0xf0, 0x1f,   // fmov d31, #7f
+    0x1e, 0x02, 0x97, 0xc0,   // scvtf s0, w30, #59
+    0x9e, 0x43, 0x24, 0x01,   // ucvtf d1, x0, #55
+    0x1e, 0x02, 0xc1, 0x45,   // scvtf s5, w10, #64
+    0x1e, 0x43, 0x84, 0x48,   // ucvtf d8, w2, #63
+    0x1e, 0x19, 0xc4, 0x0b,   // fcvtzu w12, s0, #63
+    0x9e, 0x58, 0xff, 0xfe,   // fcvtzs x30, d31, #0
+    0x9e, 0x19, 0xe1, 0x41,   // fcvtzu x1, s10, #8
+    0x1e, 0x58, 0xf1, 0x29,   // fcvtzs w9, d9, #4
+    0x1e, 0x20, 0x00, 0xa8,   // fcvtns w8, s5
+    0x1e, 0x27, 0x03, 0xc1,   // fmov s1, w30
+    0xd4, 0x10, 0x00, 0x01,   // svc #32768
+    0xd4, 0x00, 0x00, 0x03,   // smc #0
+    0xd4, 0x40, 0x03, 0xc0,   // hlt #30
+    0xd4, 0xa0, 0x00, 0x42,   // dcps2 #2
+    0xd5, 0x03, 0x30, 0x5f,   // clrex
+    0xd5, 0x03, 0x34, 0x9f,   // dsb #4
+    0xd5, 0x03, 0x31, 0xbf,   // dmb #1
+    0xd5, 0x03, 0x20, 0xbf,   // hint #5
+    0xd5, 0x03, 0x45, 0xdf,   // msr 30, #5
+    0xd5, 0x09, 0x23, 0x80,   // sys #1, #2, #3, #4, x0
+    0xd5, 0x29, 0x23, 0x9e,   // sysl #1, #2, #3, #4, x30
+    0xd5, 0x3b, 0x9c, 0xc1,   // mrs x1, pmceid0_el0
+    0xd5, 0x3b, 0xe8, 0x40,   // mrs x0, pmevcntr2_el0
+    0xd5, 0x1b, 0xe0, 0x21,   // msr cntpct_el0, x1
+    0xd5, 0x1b, 0xef, 0xc0,   // msr pmevtyper30_el0, x0
   };
+  // clang-format on
 
   reverseBuffer(buffer.data(), buffer.size());
   InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_aarch64);
 
   std::vector<Instruction> decodedInsns;
   decodedInsns.reserve(num_tests);
-  for(int idx=0; idx<num_tests; idx++) {
+  for(int idx = 0; idx < num_tests; idx++) {
     Instruction insn = d.decode();
     if(!insn.isValid()) {
-      logerror("Failed to decode test %d\n", idx+1);
+      logerror("Failed to decode test %d\n", idx + 1);
       return FAILED;
     }
     decodedInsns.push_back(insn);
   }
 
-  RegisterAST::Ptr x0 (new RegisterAST(aarch64::x0));
-  RegisterAST::Ptr x1 (new RegisterAST(aarch64::x1));
-  RegisterAST::Ptr x2 (new RegisterAST(aarch64::x2));
-  RegisterAST::Ptr x3 (new RegisterAST(aarch64::x3));
-  RegisterAST::Ptr x4 (new RegisterAST(aarch64::x4));
-  RegisterAST::Ptr x5 (new RegisterAST(aarch64::x5));
-  RegisterAST::Ptr x6 (new RegisterAST(aarch64::x6));
-  RegisterAST::Ptr x7 (new RegisterAST(aarch64::x7));
-  RegisterAST::Ptr x8 (new RegisterAST(aarch64::x8));
-  RegisterAST::Ptr x9 (new RegisterAST(aarch64::x9));
-  RegisterAST::Ptr x10(new RegisterAST(aarch64::x10));
-  RegisterAST::Ptr x11(new RegisterAST(aarch64::x11));
-  RegisterAST::Ptr x12(new RegisterAST(aarch64::x12));
-  RegisterAST::Ptr x13(new RegisterAST(aarch64::x13));
-  RegisterAST::Ptr x14(new RegisterAST(aarch64::x14));
-  RegisterAST::Ptr x15(new RegisterAST(aarch64::x15));
-  RegisterAST::Ptr x16(new RegisterAST(aarch64::x16));
-  RegisterAST::Ptr x17(new RegisterAST(aarch64::x17));
-  RegisterAST::Ptr x18(new RegisterAST(aarch64::x18));
-  RegisterAST::Ptr x19(new RegisterAST(aarch64::x19));
-  RegisterAST::Ptr x20(new RegisterAST(aarch64::x20));
-  RegisterAST::Ptr x21(new RegisterAST(aarch64::x21));
-  RegisterAST::Ptr x22(new RegisterAST(aarch64::x22));
-  RegisterAST::Ptr x23(new RegisterAST(aarch64::x23));
-  RegisterAST::Ptr x24(new RegisterAST(aarch64::x24));
-  RegisterAST::Ptr x25(new RegisterAST(aarch64::x25));
-  RegisterAST::Ptr x26(new RegisterAST(aarch64::x26));
-  RegisterAST::Ptr x27(new RegisterAST(aarch64::x27));
-  RegisterAST::Ptr x28(new RegisterAST(aarch64::x28));
-  RegisterAST::Ptr x29(new RegisterAST(aarch64::x29));
-  RegisterAST::Ptr x30(new RegisterAST(aarch64::x30));
+  auto create = [](MachRegister reg) {
+    return boost::make_shared<RegisterAST>(reg);
+  };
 
-  RegisterAST::Ptr w0 (new RegisterAST(aarch64::w0));
-  RegisterAST::Ptr w1 (new RegisterAST(aarch64::w1));
-  RegisterAST::Ptr w2 (new RegisterAST(aarch64::w2));
-  RegisterAST::Ptr w3 (new RegisterAST(aarch64::w3));
-  RegisterAST::Ptr w4 (new RegisterAST(aarch64::w4));
-  RegisterAST::Ptr w5 (new RegisterAST(aarch64::w5));
-  RegisterAST::Ptr w6 (new RegisterAST(aarch64::w6));
-  RegisterAST::Ptr w7 (new RegisterAST(aarch64::w7));
-  RegisterAST::Ptr w8 (new RegisterAST(aarch64::w8));
-  RegisterAST::Ptr w9 (new RegisterAST(aarch64::w9));
-  RegisterAST::Ptr w10(new RegisterAST(aarch64::w10));
-  RegisterAST::Ptr w11(new RegisterAST(aarch64::w11));
-  RegisterAST::Ptr w12(new RegisterAST(aarch64::w12));
-  RegisterAST::Ptr w13(new RegisterAST(aarch64::w13));
-  RegisterAST::Ptr w14(new RegisterAST(aarch64::w14));
-  RegisterAST::Ptr w15(new RegisterAST(aarch64::w15));
-  RegisterAST::Ptr w16(new RegisterAST(aarch64::w16));
-  RegisterAST::Ptr w17(new RegisterAST(aarch64::w17));
-  RegisterAST::Ptr w18(new RegisterAST(aarch64::w18));
-  RegisterAST::Ptr w19(new RegisterAST(aarch64::w19));
-  RegisterAST::Ptr w20(new RegisterAST(aarch64::w20));
-  RegisterAST::Ptr w21(new RegisterAST(aarch64::w21));
-  RegisterAST::Ptr w22(new RegisterAST(aarch64::w22));
-  RegisterAST::Ptr w23(new RegisterAST(aarch64::w23));
-  RegisterAST::Ptr w24(new RegisterAST(aarch64::w24));
-  RegisterAST::Ptr w25(new RegisterAST(aarch64::w25));
-  RegisterAST::Ptr w26(new RegisterAST(aarch64::w26));
-  RegisterAST::Ptr w27(new RegisterAST(aarch64::w27));
-  RegisterAST::Ptr w28(new RegisterAST(aarch64::w28));
-  RegisterAST::Ptr w29(new RegisterAST(aarch64::w29));
-  RegisterAST::Ptr w30(new RegisterAST(aarch64::w30));
+  RegisterAST::Ptr x0 = create(aarch64::x0);
+  RegisterAST::Ptr x1 = create(aarch64::x1);
+  RegisterAST::Ptr x2 = create(aarch64::x2);
+  RegisterAST::Ptr x3 = create(aarch64::x3);
+  RegisterAST::Ptr x4 = create(aarch64::x4);
+  RegisterAST::Ptr x5 = create(aarch64::x5);
+  RegisterAST::Ptr x6 = create(aarch64::x6);
+  RegisterAST::Ptr x7 = create(aarch64::x7);
+  RegisterAST::Ptr x8 = create(aarch64::x8);
+  RegisterAST::Ptr x9 = create(aarch64::x9);
+  RegisterAST::Ptr x10 = create(aarch64::x10);
+  RegisterAST::Ptr x11 = create(aarch64::x11);
+  RegisterAST::Ptr x12 = create(aarch64::x12);
+  RegisterAST::Ptr x13 = create(aarch64::x13);
+  RegisterAST::Ptr x14 = create(aarch64::x14);
+  RegisterAST::Ptr x15 = create(aarch64::x15);
+  RegisterAST::Ptr x16 = create(aarch64::x16);
+  RegisterAST::Ptr x17 = create(aarch64::x17);
+  RegisterAST::Ptr x18 = create(aarch64::x18);
+  RegisterAST::Ptr x19 = create(aarch64::x19);
+  RegisterAST::Ptr x20 = create(aarch64::x20);
+  RegisterAST::Ptr x21 = create(aarch64::x21);
+  RegisterAST::Ptr x22 = create(aarch64::x22);
+  RegisterAST::Ptr x23 = create(aarch64::x23);
+  RegisterAST::Ptr x24 = create(aarch64::x24);
+  RegisterAST::Ptr x25 = create(aarch64::x25);
+  RegisterAST::Ptr x26 = create(aarch64::x26);
+  RegisterAST::Ptr x27 = create(aarch64::x27);
+  RegisterAST::Ptr x28 = create(aarch64::x28);
+  RegisterAST::Ptr x29 = create(aarch64::x29);
+  RegisterAST::Ptr x30 = create(aarch64::x30);
 
-  RegisterAST::Ptr q0 (new RegisterAST(aarch64::q0));
-  RegisterAST::Ptr q1 (new RegisterAST(aarch64::q1));
-  RegisterAST::Ptr q2 (new RegisterAST(aarch64::q2));
-  RegisterAST::Ptr q3 (new RegisterAST(aarch64::q3));
-  RegisterAST::Ptr q4 (new RegisterAST(aarch64::q4));
-  RegisterAST::Ptr q5 (new RegisterAST(aarch64::q5));
-  RegisterAST::Ptr q6 (new RegisterAST(aarch64::q6));
-  RegisterAST::Ptr q7 (new RegisterAST(aarch64::q7));
-  RegisterAST::Ptr q8 (new RegisterAST(aarch64::q8));
-  RegisterAST::Ptr q9 (new RegisterAST(aarch64::q9));
-  RegisterAST::Ptr q10(new RegisterAST(aarch64::q10));
-  RegisterAST::Ptr q11(new RegisterAST(aarch64::q11));
-  RegisterAST::Ptr q12(new RegisterAST(aarch64::q12));
-  RegisterAST::Ptr q13(new RegisterAST(aarch64::q13));
-  RegisterAST::Ptr q14(new RegisterAST(aarch64::q14));
-  RegisterAST::Ptr q15(new RegisterAST(aarch64::q15));
-  RegisterAST::Ptr q16(new RegisterAST(aarch64::q16));
-  RegisterAST::Ptr q17(new RegisterAST(aarch64::q17));
-  RegisterAST::Ptr q18(new RegisterAST(aarch64::q18));
-  RegisterAST::Ptr q19(new RegisterAST(aarch64::q19));
-  RegisterAST::Ptr q20(new RegisterAST(aarch64::q20));
-  RegisterAST::Ptr q21(new RegisterAST(aarch64::q21));
-  RegisterAST::Ptr q22(new RegisterAST(aarch64::q22));
-  RegisterAST::Ptr q23(new RegisterAST(aarch64::q23));
-  RegisterAST::Ptr q24(new RegisterAST(aarch64::q24));
-  RegisterAST::Ptr q25(new RegisterAST(aarch64::q25));
-  RegisterAST::Ptr q26(new RegisterAST(aarch64::q26));
-  RegisterAST::Ptr q27(new RegisterAST(aarch64::q27));
-  RegisterAST::Ptr q28(new RegisterAST(aarch64::q28));
-  RegisterAST::Ptr q29(new RegisterAST(aarch64::q29));
-  RegisterAST::Ptr q30(new RegisterAST(aarch64::q30));
-  RegisterAST::Ptr q31(new RegisterAST(aarch64::q31));
+  RegisterAST::Ptr w0 = create(aarch64::w0);
+  RegisterAST::Ptr w1 = create(aarch64::w1);
+  RegisterAST::Ptr w2 = create(aarch64::w2);
+  RegisterAST::Ptr w3 = create(aarch64::w3);
+  RegisterAST::Ptr w4 = create(aarch64::w4);
+  RegisterAST::Ptr w5 = create(aarch64::w5);
+  RegisterAST::Ptr w6 = create(aarch64::w6);
+  RegisterAST::Ptr w7 = create(aarch64::w7);
+  RegisterAST::Ptr w8 = create(aarch64::w8);
+  RegisterAST::Ptr w9 = create(aarch64::w9);
+  RegisterAST::Ptr w10 = create(aarch64::w10);
+  RegisterAST::Ptr w11 = create(aarch64::w11);
+  RegisterAST::Ptr w12 = create(aarch64::w12);
+  RegisterAST::Ptr w13 = create(aarch64::w13);
+  RegisterAST::Ptr w14 = create(aarch64::w14);
+  RegisterAST::Ptr w15 = create(aarch64::w15);
+  RegisterAST::Ptr w16 = create(aarch64::w16);
+  RegisterAST::Ptr w17 = create(aarch64::w17);
+  RegisterAST::Ptr w18 = create(aarch64::w18);
+  RegisterAST::Ptr w19 = create(aarch64::w19);
+  RegisterAST::Ptr w20 = create(aarch64::w20);
+  RegisterAST::Ptr w21 = create(aarch64::w21);
+  RegisterAST::Ptr w22 = create(aarch64::w22);
+  RegisterAST::Ptr w23 = create(aarch64::w23);
+  RegisterAST::Ptr w24 = create(aarch64::w24);
+  RegisterAST::Ptr w25 = create(aarch64::w25);
+  RegisterAST::Ptr w26 = create(aarch64::w26);
+  RegisterAST::Ptr w27 = create(aarch64::w27);
+  RegisterAST::Ptr w28 = create(aarch64::w28);
+  RegisterAST::Ptr w29 = create(aarch64::w29);
+  RegisterAST::Ptr w30 = create(aarch64::w30);
 
-  RegisterAST::Ptr s0 (new RegisterAST(aarch64::s0));
-  RegisterAST::Ptr s1 (new RegisterAST(aarch64::s1));
-  RegisterAST::Ptr s2 (new RegisterAST(aarch64::s2));
-  RegisterAST::Ptr s3 (new RegisterAST(aarch64::s3));
-  RegisterAST::Ptr s4 (new RegisterAST(aarch64::s4));
-  RegisterAST::Ptr s5 (new RegisterAST(aarch64::s5));
-  RegisterAST::Ptr s6 (new RegisterAST(aarch64::s6));
-  RegisterAST::Ptr s7 (new RegisterAST(aarch64::s7));
-  RegisterAST::Ptr s8 (new RegisterAST(aarch64::s8));
-  RegisterAST::Ptr s9 (new RegisterAST(aarch64::s9));
-  RegisterAST::Ptr s10(new RegisterAST(aarch64::s10));
-  RegisterAST::Ptr s11(new RegisterAST(aarch64::s11));
-  RegisterAST::Ptr s12(new RegisterAST(aarch64::s12));
-  RegisterAST::Ptr s13(new RegisterAST(aarch64::s13));
-  RegisterAST::Ptr s14(new RegisterAST(aarch64::s14));
-  RegisterAST::Ptr s15(new RegisterAST(aarch64::s15));
-  RegisterAST::Ptr s16(new RegisterAST(aarch64::s16));
-  RegisterAST::Ptr s17(new RegisterAST(aarch64::s17));
-  RegisterAST::Ptr s18(new RegisterAST(aarch64::s18));
-  RegisterAST::Ptr s19(new RegisterAST(aarch64::s19));
-  RegisterAST::Ptr s20(new RegisterAST(aarch64::s20));
-  RegisterAST::Ptr s21(new RegisterAST(aarch64::s21));
-  RegisterAST::Ptr s22(new RegisterAST(aarch64::s22));
-  RegisterAST::Ptr s23(new RegisterAST(aarch64::s23));
-  RegisterAST::Ptr s24(new RegisterAST(aarch64::s24));
-  RegisterAST::Ptr s25(new RegisterAST(aarch64::s25));
-  RegisterAST::Ptr s26(new RegisterAST(aarch64::s26));
-  RegisterAST::Ptr s27(new RegisterAST(aarch64::s27));
-  RegisterAST::Ptr s28(new RegisterAST(aarch64::s28));
-  RegisterAST::Ptr s29(new RegisterAST(aarch64::s29));
-  RegisterAST::Ptr s30(new RegisterAST(aarch64::s30));
-  RegisterAST::Ptr s31(new RegisterAST(aarch64::s31));
+  RegisterAST::Ptr q0 = create(aarch64::q0);
+  RegisterAST::Ptr q1 = create(aarch64::q1);
+  RegisterAST::Ptr q2 = create(aarch64::q2);
+  RegisterAST::Ptr q3 = create(aarch64::q3);
+  RegisterAST::Ptr q4 = create(aarch64::q4);
+  RegisterAST::Ptr q5 = create(aarch64::q5);
+  RegisterAST::Ptr q6 = create(aarch64::q6);
+  RegisterAST::Ptr q7 = create(aarch64::q7);
+  RegisterAST::Ptr q8 = create(aarch64::q8);
+  RegisterAST::Ptr q9 = create(aarch64::q9);
+  RegisterAST::Ptr q10 = create(aarch64::q10);
+  RegisterAST::Ptr q11 = create(aarch64::q11);
+  RegisterAST::Ptr q12 = create(aarch64::q12);
+  RegisterAST::Ptr q13 = create(aarch64::q13);
+  RegisterAST::Ptr q14 = create(aarch64::q14);
+  RegisterAST::Ptr q15 = create(aarch64::q15);
+  RegisterAST::Ptr q16 = create(aarch64::q16);
+  RegisterAST::Ptr q17 = create(aarch64::q17);
+  RegisterAST::Ptr q18 = create(aarch64::q18);
+  RegisterAST::Ptr q19 = create(aarch64::q19);
+  RegisterAST::Ptr q20 = create(aarch64::q20);
+  RegisterAST::Ptr q21 = create(aarch64::q21);
+  RegisterAST::Ptr q22 = create(aarch64::q22);
+  RegisterAST::Ptr q23 = create(aarch64::q23);
+  RegisterAST::Ptr q24 = create(aarch64::q24);
+  RegisterAST::Ptr q25 = create(aarch64::q25);
+  RegisterAST::Ptr q26 = create(aarch64::q26);
+  RegisterAST::Ptr q27 = create(aarch64::q27);
+  RegisterAST::Ptr q28 = create(aarch64::q28);
+  RegisterAST::Ptr q29 = create(aarch64::q29);
+  RegisterAST::Ptr q30 = create(aarch64::q30);
+  RegisterAST::Ptr q31 = create(aarch64::q31);
 
-  RegisterAST::Ptr h0 (new RegisterAST(aarch64::h0));
-  RegisterAST::Ptr h1 (new RegisterAST(aarch64::h1));
-  RegisterAST::Ptr h2 (new RegisterAST(aarch64::h2));
-  RegisterAST::Ptr h3 (new RegisterAST(aarch64::h3));
-  RegisterAST::Ptr h4 (new RegisterAST(aarch64::h4));
-  RegisterAST::Ptr h5 (new RegisterAST(aarch64::h5));
-  RegisterAST::Ptr h6 (new RegisterAST(aarch64::h6));
-  RegisterAST::Ptr h7 (new RegisterAST(aarch64::h7));
-  RegisterAST::Ptr h8 (new RegisterAST(aarch64::h8));
-  RegisterAST::Ptr h9 (new RegisterAST(aarch64::h9));
-  RegisterAST::Ptr h10(new RegisterAST(aarch64::h10));
-  RegisterAST::Ptr h11(new RegisterAST(aarch64::h11));
-  RegisterAST::Ptr h12(new RegisterAST(aarch64::h12));
-  RegisterAST::Ptr h13(new RegisterAST(aarch64::h13));
-  RegisterAST::Ptr h14(new RegisterAST(aarch64::h14));
-  RegisterAST::Ptr h15(new RegisterAST(aarch64::h15));
-  RegisterAST::Ptr h16(new RegisterAST(aarch64::h16));
-  RegisterAST::Ptr h17(new RegisterAST(aarch64::h17));
-  RegisterAST::Ptr h18(new RegisterAST(aarch64::h18));
-  RegisterAST::Ptr h19(new RegisterAST(aarch64::h19));
-  RegisterAST::Ptr h20(new RegisterAST(aarch64::h20));
-  RegisterAST::Ptr h21(new RegisterAST(aarch64::h21));
-  RegisterAST::Ptr h22(new RegisterAST(aarch64::h22));
-  RegisterAST::Ptr h23(new RegisterAST(aarch64::h23));
-  RegisterAST::Ptr h24(new RegisterAST(aarch64::h24));
-  RegisterAST::Ptr h25(new RegisterAST(aarch64::h25));
-  RegisterAST::Ptr h26(new RegisterAST(aarch64::h26));
-  RegisterAST::Ptr h27(new RegisterAST(aarch64::h27));
-  RegisterAST::Ptr h28(new RegisterAST(aarch64::h28));
-  RegisterAST::Ptr h29(new RegisterAST(aarch64::h29));
-  RegisterAST::Ptr h30(new RegisterAST(aarch64::h30));
-  RegisterAST::Ptr h31(new RegisterAST(aarch64::h31));
+  RegisterAST::Ptr s0 = create(aarch64::s0);
+  RegisterAST::Ptr s1 = create(aarch64::s1);
+  RegisterAST::Ptr s2 = create(aarch64::s2);
+  RegisterAST::Ptr s3 = create(aarch64::s3);
+  RegisterAST::Ptr s4 = create(aarch64::s4);
+  RegisterAST::Ptr s5 = create(aarch64::s5);
+  RegisterAST::Ptr s6 = create(aarch64::s6);
+  RegisterAST::Ptr s7 = create(aarch64::s7);
+  RegisterAST::Ptr s8 = create(aarch64::s8);
+  RegisterAST::Ptr s9 = create(aarch64::s9);
+  RegisterAST::Ptr s10 = create(aarch64::s10);
+  RegisterAST::Ptr s11 = create(aarch64::s11);
+  RegisterAST::Ptr s12 = create(aarch64::s12);
+  RegisterAST::Ptr s13 = create(aarch64::s13);
+  RegisterAST::Ptr s14 = create(aarch64::s14);
+  RegisterAST::Ptr s15 = create(aarch64::s15);
+  RegisterAST::Ptr s16 = create(aarch64::s16);
+  RegisterAST::Ptr s17 = create(aarch64::s17);
+  RegisterAST::Ptr s18 = create(aarch64::s18);
+  RegisterAST::Ptr s19 = create(aarch64::s19);
+  RegisterAST::Ptr s20 = create(aarch64::s20);
+  RegisterAST::Ptr s21 = create(aarch64::s21);
+  RegisterAST::Ptr s22 = create(aarch64::s22);
+  RegisterAST::Ptr s23 = create(aarch64::s23);
+  RegisterAST::Ptr s24 = create(aarch64::s24);
+  RegisterAST::Ptr s25 = create(aarch64::s25);
+  RegisterAST::Ptr s26 = create(aarch64::s26);
+  RegisterAST::Ptr s27 = create(aarch64::s27);
+  RegisterAST::Ptr s28 = create(aarch64::s28);
+  RegisterAST::Ptr s29 = create(aarch64::s29);
+  RegisterAST::Ptr s30 = create(aarch64::s30);
+  RegisterAST::Ptr s31 = create(aarch64::s31);
 
-  RegisterAST::Ptr d0 (new RegisterAST(aarch64::d0));
-  RegisterAST::Ptr d1 (new RegisterAST(aarch64::d1));
-  RegisterAST::Ptr d2 (new RegisterAST(aarch64::d2));
-  RegisterAST::Ptr d3 (new RegisterAST(aarch64::d3));
-  RegisterAST::Ptr d4 (new RegisterAST(aarch64::d4));
-  RegisterAST::Ptr d5 (new RegisterAST(aarch64::d5));
-  RegisterAST::Ptr d6 (new RegisterAST(aarch64::d6));
-  RegisterAST::Ptr d7 (new RegisterAST(aarch64::d7));
-  RegisterAST::Ptr d8 (new RegisterAST(aarch64::d8));
-  RegisterAST::Ptr d9 (new RegisterAST(aarch64::d9));
-  RegisterAST::Ptr d10(new RegisterAST(aarch64::d10));
-  RegisterAST::Ptr d11(new RegisterAST(aarch64::d11));
-  RegisterAST::Ptr d12(new RegisterAST(aarch64::d12));
-  RegisterAST::Ptr d13(new RegisterAST(aarch64::d13));
-  RegisterAST::Ptr d14(new RegisterAST(aarch64::d14));
-  RegisterAST::Ptr d15(new RegisterAST(aarch64::d15));
-  RegisterAST::Ptr d16(new RegisterAST(aarch64::d16));
-  RegisterAST::Ptr d17(new RegisterAST(aarch64::d17));
-  RegisterAST::Ptr d18(new RegisterAST(aarch64::d18));
-  RegisterAST::Ptr d19(new RegisterAST(aarch64::d19));
-  RegisterAST::Ptr d20(new RegisterAST(aarch64::d20));
-  RegisterAST::Ptr d21(new RegisterAST(aarch64::d21));
-  RegisterAST::Ptr d22(new RegisterAST(aarch64::d22));
-  RegisterAST::Ptr d23(new RegisterAST(aarch64::d23));
-  RegisterAST::Ptr d24(new RegisterAST(aarch64::d24));
-  RegisterAST::Ptr d25(new RegisterAST(aarch64::d25));
-  RegisterAST::Ptr d26(new RegisterAST(aarch64::d26));
-  RegisterAST::Ptr d27(new RegisterAST(aarch64::d27));
-  RegisterAST::Ptr d28(new RegisterAST(aarch64::d28));
-  RegisterAST::Ptr d29(new RegisterAST(aarch64::d29));
-  RegisterAST::Ptr d30(new RegisterAST(aarch64::d30));
-  RegisterAST::Ptr d31(new RegisterAST(aarch64::d31));
+  RegisterAST::Ptr h0 = create(aarch64::h0);
+  RegisterAST::Ptr h1 = create(aarch64::h1);
+  RegisterAST::Ptr h2 = create(aarch64::h2);
+  RegisterAST::Ptr h3 = create(aarch64::h3);
+  RegisterAST::Ptr h4 = create(aarch64::h4);
+  RegisterAST::Ptr h5 = create(aarch64::h5);
+  RegisterAST::Ptr h6 = create(aarch64::h6);
+  RegisterAST::Ptr h7 = create(aarch64::h7);
+  RegisterAST::Ptr h8 = create(aarch64::h8);
+  RegisterAST::Ptr h9 = create(aarch64::h9);
+  RegisterAST::Ptr h10 = create(aarch64::h10);
+  RegisterAST::Ptr h11 = create(aarch64::h11);
+  RegisterAST::Ptr h12 = create(aarch64::h12);
+  RegisterAST::Ptr h13 = create(aarch64::h13);
+  RegisterAST::Ptr h14 = create(aarch64::h14);
+  RegisterAST::Ptr h15 = create(aarch64::h15);
+  RegisterAST::Ptr h16 = create(aarch64::h16);
+  RegisterAST::Ptr h17 = create(aarch64::h17);
+  RegisterAST::Ptr h18 = create(aarch64::h18);
+  RegisterAST::Ptr h19 = create(aarch64::h19);
+  RegisterAST::Ptr h20 = create(aarch64::h20);
+  RegisterAST::Ptr h21 = create(aarch64::h21);
+  RegisterAST::Ptr h22 = create(aarch64::h22);
+  RegisterAST::Ptr h23 = create(aarch64::h23);
+  RegisterAST::Ptr h24 = create(aarch64::h24);
+  RegisterAST::Ptr h25 = create(aarch64::h25);
+  RegisterAST::Ptr h26 = create(aarch64::h26);
+  RegisterAST::Ptr h27 = create(aarch64::h27);
+  RegisterAST::Ptr h28 = create(aarch64::h28);
+  RegisterAST::Ptr h29 = create(aarch64::h29);
+  RegisterAST::Ptr h30 = create(aarch64::h30);
+  RegisterAST::Ptr h31 = create(aarch64::h31);
 
-  RegisterAST::Ptr b0 (new RegisterAST(aarch64::b0));
-  RegisterAST::Ptr b1 (new RegisterAST(aarch64::b1));
-  RegisterAST::Ptr b2 (new RegisterAST(aarch64::b2));
-  RegisterAST::Ptr b3 (new RegisterAST(aarch64::b3));
-  RegisterAST::Ptr b4 (new RegisterAST(aarch64::b4));
-  RegisterAST::Ptr b5 (new RegisterAST(aarch64::b5));
-  RegisterAST::Ptr b6 (new RegisterAST(aarch64::b6));
-  RegisterAST::Ptr b7 (new RegisterAST(aarch64::b7));
-  RegisterAST::Ptr b8 (new RegisterAST(aarch64::b8));
-  RegisterAST::Ptr b9 (new RegisterAST(aarch64::b9));
-  RegisterAST::Ptr b10(new RegisterAST(aarch64::b10));
-  RegisterAST::Ptr b11(new RegisterAST(aarch64::b11));
-  RegisterAST::Ptr b12(new RegisterAST(aarch64::b12));
-  RegisterAST::Ptr b13(new RegisterAST(aarch64::b13));
-  RegisterAST::Ptr b14(new RegisterAST(aarch64::b14));
-  RegisterAST::Ptr b15(new RegisterAST(aarch64::b15));
-  RegisterAST::Ptr b16(new RegisterAST(aarch64::b16));
-  RegisterAST::Ptr b17(new RegisterAST(aarch64::b17));
-  RegisterAST::Ptr b18(new RegisterAST(aarch64::b18));
-  RegisterAST::Ptr b19(new RegisterAST(aarch64::b19));
-  RegisterAST::Ptr b20(new RegisterAST(aarch64::b20));
-  RegisterAST::Ptr b21(new RegisterAST(aarch64::b21));
-  RegisterAST::Ptr b22(new RegisterAST(aarch64::b22));
-  RegisterAST::Ptr b23(new RegisterAST(aarch64::b23));
-  RegisterAST::Ptr b24(new RegisterAST(aarch64::b24));
-  RegisterAST::Ptr b25(new RegisterAST(aarch64::b25));
-  RegisterAST::Ptr b26(new RegisterAST(aarch64::b26));
-  RegisterAST::Ptr b27(new RegisterAST(aarch64::b27));
-  RegisterAST::Ptr b28(new RegisterAST(aarch64::b28));
-  RegisterAST::Ptr b29(new RegisterAST(aarch64::b29));
-  RegisterAST::Ptr b30(new RegisterAST(aarch64::b30));
-  RegisterAST::Ptr b31(new RegisterAST(aarch64::b31));
+  RegisterAST::Ptr d0 = create(aarch64::d0);
+  RegisterAST::Ptr d1 = create(aarch64::d1);
+  RegisterAST::Ptr d2 = create(aarch64::d2);
+  RegisterAST::Ptr d3 = create(aarch64::d3);
+  RegisterAST::Ptr d4 = create(aarch64::d4);
+  RegisterAST::Ptr d5 = create(aarch64::d5);
+  RegisterAST::Ptr d6 = create(aarch64::d6);
+  RegisterAST::Ptr d7 = create(aarch64::d7);
+  RegisterAST::Ptr d8 = create(aarch64::d8);
+  RegisterAST::Ptr d9 = create(aarch64::d9);
+  RegisterAST::Ptr d10 = create(aarch64::d10);
+  RegisterAST::Ptr d11 = create(aarch64::d11);
+  RegisterAST::Ptr d12 = create(aarch64::d12);
+  RegisterAST::Ptr d13 = create(aarch64::d13);
+  RegisterAST::Ptr d14 = create(aarch64::d14);
+  RegisterAST::Ptr d15 = create(aarch64::d15);
+  RegisterAST::Ptr d16 = create(aarch64::d16);
+  RegisterAST::Ptr d17 = create(aarch64::d17);
+  RegisterAST::Ptr d18 = create(aarch64::d18);
+  RegisterAST::Ptr d19 = create(aarch64::d19);
+  RegisterAST::Ptr d20 = create(aarch64::d20);
+  RegisterAST::Ptr d21 = create(aarch64::d21);
+  RegisterAST::Ptr d22 = create(aarch64::d22);
+  RegisterAST::Ptr d23 = create(aarch64::d23);
+  RegisterAST::Ptr d24 = create(aarch64::d24);
+  RegisterAST::Ptr d25 = create(aarch64::d25);
+  RegisterAST::Ptr d26 = create(aarch64::d26);
+  RegisterAST::Ptr d27 = create(aarch64::d27);
+  RegisterAST::Ptr d28 = create(aarch64::d28);
+  RegisterAST::Ptr d29 = create(aarch64::d29);
+  RegisterAST::Ptr d30 = create(aarch64::d30);
+  RegisterAST::Ptr d31 = create(aarch64::d31);
 
-  RegisterAST::Ptr zr (new RegisterAST(aarch64::xzr));
-  RegisterAST::Ptr wzr (new RegisterAST(aarch64::wzr));
-  RegisterAST::Ptr sp (new RegisterAST(aarch64::sp));
-  RegisterAST::Ptr wsp (new RegisterAST(aarch64::wsp));
-  RegisterAST::Ptr pc (new RegisterAST(aarch64::pc));
-  RegisterAST::Ptr nzcv (new RegisterAST(aarch64::nzcv));
+  RegisterAST::Ptr b0 = create(aarch64::b0);
+  RegisterAST::Ptr b1 = create(aarch64::b1);
+  RegisterAST::Ptr b2 = create(aarch64::b2);
+  RegisterAST::Ptr b3 = create(aarch64::b3);
+  RegisterAST::Ptr b4 = create(aarch64::b4);
+  RegisterAST::Ptr b5 = create(aarch64::b5);
+  RegisterAST::Ptr b6 = create(aarch64::b6);
+  RegisterAST::Ptr b7 = create(aarch64::b7);
+  RegisterAST::Ptr b8 = create(aarch64::b8);
+  RegisterAST::Ptr b9 = create(aarch64::b9);
+  RegisterAST::Ptr b10 = create(aarch64::b10);
+  RegisterAST::Ptr b11 = create(aarch64::b11);
+  RegisterAST::Ptr b12 = create(aarch64::b12);
+  RegisterAST::Ptr b13 = create(aarch64::b13);
+  RegisterAST::Ptr b14 = create(aarch64::b14);
+  RegisterAST::Ptr b15 = create(aarch64::b15);
+  RegisterAST::Ptr b16 = create(aarch64::b16);
+  RegisterAST::Ptr b17 = create(aarch64::b17);
+  RegisterAST::Ptr b18 = create(aarch64::b18);
+  RegisterAST::Ptr b19 = create(aarch64::b19);
+  RegisterAST::Ptr b20 = create(aarch64::b20);
+  RegisterAST::Ptr b21 = create(aarch64::b21);
+  RegisterAST::Ptr b22 = create(aarch64::b22);
+  RegisterAST::Ptr b23 = create(aarch64::b23);
+  RegisterAST::Ptr b24 = create(aarch64::b24);
+  RegisterAST::Ptr b25 = create(aarch64::b25);
+  RegisterAST::Ptr b26 = create(aarch64::b26);
+  RegisterAST::Ptr b27 = create(aarch64::b27);
+  RegisterAST::Ptr b28 = create(aarch64::b28);
+  RegisterAST::Ptr b29 = create(aarch64::b29);
+  RegisterAST::Ptr b30 = create(aarch64::b30);
+  RegisterAST::Ptr b31 = create(aarch64::b31);
 
-  RegisterAST::Ptr pmceid0_el0(new RegisterAST(aarch64::pmceid0_el0));
-  RegisterAST::Ptr pmevcntr2_el0(new RegisterAST(aarch64::pmevcntr2_el0));
-  RegisterAST::Ptr cntpct_el0(new RegisterAST(aarch64::cntpct_el0));
-  RegisterAST::Ptr pmevtyper30_el0(new RegisterAST(aarch64::pmevtyper30_el0));
+  RegisterAST::Ptr xzr = create(aarch64::xzr);
+  RegisterAST::Ptr wzr = create(aarch64::wzr);
+  RegisterAST::Ptr sp = create(aarch64::sp);
+  RegisterAST::Ptr wsp = create(aarch64::wsp);
+  RegisterAST::Ptr pc = create(aarch64::pc);
+  RegisterAST::Ptr nzcv = create(aarch64::nzcv);
+
+  RegisterAST::Ptr pmceid0_el0 = create(aarch64::pmceid0_el0);
+  RegisterAST::Ptr pmevcntr2_el0 = create(aarch64::pmevcntr2_el0);
+  RegisterAST::Ptr cntpct_el0 = create(aarch64::cntpct_el0);
+  RegisterAST::Ptr pmevtyper30_el0 = create(aarch64::pmevtyper30_el0);
 
   std::deque<registerSet> expectedRead, expectedWritten;
 
   // ADD W1, W10, W12
-  expectedRead.push_back({w12,w10});
+  expectedRead.push_back({w12, w10});
   expectedWritten.push_back({w1});
 
   // ADD W0, W5, W8, LSL #5
-  expectedRead.push_back({w8,w5});
+  expectedRead.push_back({w8, w5});
   expectedWritten.push_back({w0});
 
   // ADD X4, X7, X9, LSR #10
-  expectedRead.push_back({x9,x7});
+  expectedRead.push_back({x9, x7});
   expectedWritten.push_back({x4});
 
   // SUB W0, W2, W4
-  expectedRead.push_back({w4,w2});
+  expectedRead.push_back({w4, w2});
   expectedWritten.push_back({w0});
 
   // SUB X6, X8, X11, ASR #7
-  expectedRead.push_back({x11,x8});
+  expectedRead.push_back({x11, x8});
   expectedWritten.push_back({x6});
 
   // ADDS W0, W5, W8, LSL #5
-  expectedRead.push_back({w8,w5});
-  expectedWritten.push_back({w0,nzcv});
+  expectedRead.push_back({w8, w5});
+  expectedWritten.push_back({w0, nzcv});
 
   // ADD W5, W10, W15
-  expectedRead.push_back({x15,w10});
+  expectedRead.push_back({x15, w10});
   expectedWritten.push_back({w5});
 
   // SUB X0, X1, X1, UXTB #0
-  expectedRead.push_back({w1,x1});
+  expectedRead.push_back({w1, x1});
   expectedWritten.push_back({x0});
 
   // SUBS X2, X2, X2, SXTW #4
-  expectedRead.push_back({x2,x2});
-  expectedWritten.push_back({x2,nzcv});
+  expectedRead.push_back({x2, x2});
+  expectedWritten.push_back({x2, nzcv});
 
   // ADC W5, W22, W25
-  expectedRead.push_back({w25,w22});
+  expectedRead.push_back({w25, w22});
   expectedWritten.push_back({w5});
 
   // SBC X0, X1, X2
-  expectedRead.push_back({x2,x1});
+  expectedRead.push_back({x2, x1});
   expectedWritten.push_back({x0});
 
   // CCMN W7, #30, #11, 5
-  expectedRead.push_back({w7,nzcv});
+  expectedRead.push_back({w7, nzcv});
   expectedWritten.push_back({nzcv});
 
   // CCMP X20, #8, #0, 15
-  expectedRead.push_back({x20,nzcv});
+  expectedRead.push_back({x20, nzcv});
   expectedWritten.push_back({nzcv});
 
   // CCMN W5, W10, #7, 1
-  expectedRead.push_back({w10,w5,nzcv});
+  expectedRead.push_back({w10, w5, nzcv});
   expectedWritten.push_back({nzcv});
 
   // CCMP X2, X4, #4, 10
-  expectedRead.push_back({x2,x4,nzcv});
+  expectedRead.push_back({x2, x4, nzcv});
   expectedWritten.push_back({nzcv});
 
   // CSEL W5, W10, W15, 1
-  expectedRead.push_back({w15,w10,nzcv});
+  expectedRead.push_back({w15, w10, nzcv});
   expectedWritten.push_back({w5});
 
   // CSINC X0, X2, X4, 5
-  expectedRead.push_back({x2,x4,nzcv});
+  expectedRead.push_back({x2, x4, nzcv});
   expectedWritten.push_back({x0});
 
   // CSINV X20, X21, X22, 7
-  expectedRead.push_back({x21,x22,nzcv});
+  expectedRead.push_back({x21, x22, nzcv});
   expectedWritten.push_back({x20});
 
   // CSNEG W1, W5, W9, 10
-  expectedRead.push_back({w5,w10,nzcv});
+  expectedRead.push_back({w5, w10, nzcv});
   expectedWritten.push_back({w1});
 
   // RBIT W1, W2
@@ -549,60 +550,60 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({w0});
 
   // UDIV W0, W2, W4
-  expectedRead.push_back({w4,w2});
+  expectedRead.push_back({w4, w2});
   expectedWritten.push_back({w0});
 
   // SDIV X15, X20, X25
-  expectedRead.push_back({x25,x20});
+  expectedRead.push_back({x25, x20});
   expectedWritten.push_back({x15});
 
   // LSLV W5, W8, W11
-  expectedRead.push_back({w11,w8});
+  expectedRead.push_back({w11, w8});
   expectedWritten.push_back({w5});
 
   // ASRV X7, X9, X11
-  expectedRead.push_back({x11,x9});
+  expectedRead.push_back({x11, x9});
   expectedWritten.push_back({x7});
 
   // RORV W16, W0, W4
-  expectedRead.push_back({w4,w0});
+  expectedRead.push_back({w4, w0});
   expectedWritten.push_back({w16});
 
   // MADD W1, W3, W2, W0
-  expectedRead.push_back({w2,w0,w3});
+  expectedRead.push_back({w2, w0, w3});
   expectedWritten.push_back({w1});
 
   // MSUB X4, X8, X16, X30
-  expectedRead.push_back({x16,x30,x8});
+  expectedRead.push_back({x16, x30, x8});
   expectedWritten.push_back({x4});
 
   // SMSUBL X0, X0, X1, X1
-  expectedRead.push_back({x1,w1,w0});
+  expectedRead.push_back({x1, w1, w0});
   expectedWritten.push_back({x0});
 
   // UMULH W5, W5, W10, W10
-  expectedRead.push_back({x10,x5});
+  expectedRead.push_back({x10, x5});
   expectedWritten.push_back({x5});
 
   // AND W1, W2, W3
-  expectedRead.push_back({w3,w2});
+  expectedRead.push_back({w3, w2});
   expectedWritten.push_back({w1});
 
   // BIC X0, X5, X10, LSL #5
-  expectedRead.push_back({x10,x5});
+  expectedRead.push_back({x10, x5});
   expectedWritten.push_back({x0});
 
   // ORN W0, W0, W2, LSR #10
-  expectedRead.push_back({w2,w0});
+  expectedRead.push_back({w2, w0});
   expectedWritten.push_back({w0});
 
   // EOR X20, X21, X22, ASR #2
-  expectedRead.push_back({x22,x21});
+  expectedRead.push_back({x22, x21});
   expectedWritten.push_back({x20});
 
   // BICS X1, X1, X1, ROR #8
-  expectedRead.push_back({x1,x1});
-  expectedWritten.push_back({x1,nzcv});
+  expectedRead.push_back({x1, x1});
+  expectedWritten.push_back({x1, nzcv});
 
   // ADD W0, WSP, #11
   expectedRead.push_back({wsp});
@@ -610,7 +611,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // ADDS W5, W10, #0, LSL #12
   expectedRead.push_back({w10});
-  expectedWritten.push_back({w5,nzcv});
+  expectedWritten.push_back({w5, nzcv});
 
   // SUB SP, X10, #12
   expectedRead.push_back({x10});
@@ -629,11 +630,11 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({x20});
 
   // EXTR W10, W20, W30, #5
-  expectedRead.push_back({w30,w20});
+  expectedRead.push_back({w30, w20});
   expectedWritten.push_back({w10});
 
   // EXTR X0, X8, X16, #63
-  expectedRead.push_back({x16,x8});
+  expectedRead.push_back({x16, x8});
   expectedWritten.push_back({x0});
 
   // AND WSP, W24, #63
@@ -650,7 +651,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // ANDS W5, W10, #9
   expectedRead.push_back({w10});
-  expectedWritten.push_back({w5,nzcv});
+  expectedWritten.push_back({w5, nzcv});
 
   // MOVN W4, #23, LSL #1
   expectedRead.push_back({});
@@ -677,31 +678,31 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({x30});
 
   // CBZ W15, #
-  expectedRead.push_back({w15,pc});
+  expectedRead.push_back({w15, pc});
   expectedWritten.push_back({pc});
 
   // CBNZ X30, #1
-  expectedRead.push_back({x30,pc});
+  expectedRead.push_back({x30, pc});
   expectedWritten.push_back({pc});
 
   // B.NE #
-  expectedRead.push_back({pc,nzcv});
+  expectedRead.push_back({pc, nzcv});
   expectedWritten.push_back({pc});
 
   // B.GT #63
-  expectedRead.push_back({pc,nzcv});
+  expectedRead.push_back({pc, nzcv});
   expectedWritten.push_back({pc});
 
   // TBZ W4, #30, #
-  expectedRead.push_back({w4,pc});
+  expectedRead.push_back({w4, pc});
   expectedWritten.push_back({pc});
 
   // TBNZ X25, #0, #16
-  expectedRead.push_back({x25,pc});
+  expectedRead.push_back({x25, pc});
   expectedWritten.push_back({pc});
 
   // TBNZ WZR, #9, #12
-  expectedRead.push_back({wzr,pc});
+  expectedRead.push_back({wzr, pc});
   expectedWritten.push_back({pc});
 
   // B #
@@ -725,7 +726,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({pc});
 
   // FCMP S0, S31
-  expectedRead.push_back({s31,s0});
+  expectedRead.push_back({s31, s0});
   expectedWritten.push_back({nzcv});
 
   // FCMP D16, #0.0
@@ -733,23 +734,23 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({nzcv});
 
   // FCMP D31, D32
-  expectedRead.push_back({d31,d30});
+  expectedRead.push_back({d31, d30});
   expectedWritten.push_back({nzcv});
 
   // FCCMP S20, S31, #8, 10
-  expectedRead.push_back({s31,s20,nzcv});
+  expectedRead.push_back({s31, s20, nzcv});
   expectedWritten.push_back({nzcv});
 
   // FCCMP D1, D2, #5, 0
-  expectedRead.push_back({d2,d1,nzcv});
+  expectedRead.push_back({d2, d1, nzcv});
   expectedWritten.push_back({nzcv});
 
   // FCCMPE D10, D1,, #9, 5
-  expectedRead.push_back({d11,d10,nzcv});
+  expectedRead.push_back({d11, d10, nzcv});
   expectedWritten.push_back({nzcv});
 
   // FCSEL S1, S, S3, 4
-  expectedRead.push_back({s3,s2,nzcv});
+  expectedRead.push_back({s3, s2, nzcv});
   expectedWritten.push_back({s1});
 
   // FMOV S5, S10
@@ -789,39 +790,39 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({h8});
 
   // FMUL S0, S1, S2
-  expectedRead.push_back({s2,s1});
+  expectedRead.push_back({s2, s1});
   expectedWritten.push_back({s0});
 
   // FSUB D29, D30, D31
-  expectedRead.push_back({d31,d30});
+  expectedRead.push_back({d31, d30});
   expectedWritten.push_back({d29});
 
   // FDIV D5, D10, D15
-  expectedRead.push_back({d15,d10});
+  expectedRead.push_back({d15, d10});
   expectedWritten.push_back({d5});
 
   // FMAX S8, S16, S0
-  expectedRead.push_back({s0,s16});
+  expectedRead.push_back({s0, s16});
   expectedWritten.push_back({s8});
 
   // FNINNM S1, S1, S1
-  expectedRead.push_back({s1,s1});
+  expectedRead.push_back({s1, s1});
   expectedWritten.push_back({s1});
 
   // FMADD S0, S1, S2, S3
-  expectedRead.push_back({s2,s3,s1});
+  expectedRead.push_back({s2, s3, s1});
   expectedWritten.push_back({s0});
 
   // FMSUB D2, D4, D8, D16
-  expectedRead.push_back({d8,d16,d4});
+  expectedRead.push_back({d8, d16, d4});
   expectedWritten.push_back({d2});
 
   // FNMADD S10, S11, S11, S13
-  expectedRead.push_back({s11,s13,s11});
+  expectedRead.push_back({s11, s13, s11});
   expectedWritten.push_back({s10});
 
   // FNMSUB D8, D4, D2, D1
-  expectedRead.push_back({d2,d1,d4});
+  expectedRead.push_back({d2, d1, d4});
   expectedWritten.push_back({d8});
 
   // FMOV S0, #88
@@ -932,16 +933,27 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedRead.push_back({x0});
   expectedWritten.push_back({pmevtyper30_el0});
 
+  if(expectedRead.size() != expectedWritten.size()) {
+    logerror("FATAL: expectedRead.size() != expectedWritten.size()");
+    return FAILED;
+  }
+
+  if(expectedRead.size() != decodedInsns.size()) {
+    logerror("FATAL: expectedRead.size() != decodedInsns.size()");
+    return FAILED;
+  }
+
   test_results_t retVal = PASSED;
-  for(auto insn : decodedInsns) {
-    auto status = verify_read_write_sets(insn, expectedRead.front(), expectedWritten.front());
+  for(auto&& x : boost::combine(decodedInsns, expectedRead, expectedWritten)) {
+    auto insn = x.get<0>();
+    auto read = x.get<1>();
+    auto written = x.get<2>();
+
+    auto status = verify_read_write_sets(insn, read, written);
     if(status == FAILED) {
       retVal = FAILED;
     }
-    expectedRead.pop_front();
-    expectedWritten.pop_front();
   }
 
   return retVal;
 }
-

--- a/src/instruction/aarch64_decode_ldst.C
+++ b/src/instruction/aarch64_decode_ldst.C
@@ -28,65 +28,52 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "instruction_comp.h"
-#include "test_lib.h"
-
 #include "Instruction.h"
+#include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
 #include "registers/aarch64_regs.h"
-#include <boost/assign/list_of.hpp>
-#include <boost/iterator/indirect_iterator.hpp>
-#include <deque>
-#include <iostream>
+#include "test_lib.h"
+
+#include <array>
+#include <boost/range/combine.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <vector>
+
 using namespace Dyninst;
 using namespace InstructionAPI;
-using namespace boost;
-using namespace boost::assign;
-
-using namespace std;
 
 class aarch64_decode_ldst_Mutator : public InstructionMutator {
-private:
-	void setupRegisters();
-	void reverseBuffer(const unsigned char *, int);
 public:
-    aarch64_decode_ldst_Mutator() { };
-   virtual test_results_t executeTest();
+  aarch64_decode_ldst_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* aarch64_decode_ldst_factory()
-{
-   return new aarch64_decode_ldst_Mutator();
+extern "C" DLLEXPORT TestMutator* aarch64_decode_ldst_factory() {
+  return new aarch64_decode_ldst_Mutator();
 }
 
-void aarch64_decode_ldst_Mutator::reverseBuffer(const unsigned char *buffer, int bufferSize)
-{
-    int elementCount = bufferSize/4;
-    unsigned char *currentElement = const_cast<unsigned char *>(buffer);
+static void reverseBuffer(unsigned char* buffer, int bufferSize) {
+  int elementCount = bufferSize / 4;
 
-    for(int loop_index = 0; loop_index < elementCount; loop_index++)
-    {
-	std::swap(currentElement[0], currentElement[3]);
-	std::swap(currentElement[1], currentElement[2]);
-
-	currentElement += 4;
-    }	
+  for(int loop_index = 0; loop_index < elementCount; loop_index++) {
+    std::swap(buffer[0], buffer[3]);
+    std::swap(buffer[1], buffer[2]);
+    buffer += 4;
+  }
 }
 
-test_results_t aarch64_decode_ldst_Mutator::executeTest()
-{
-  const unsigned char buffer[] =
-  {
-    
+test_results_t aarch64_decode_ldst_Mutator::executeTest() {
+  constexpr auto num_tests = 136;
 
+  // clang-format off
+  std::array<unsigned char, 4*num_tests> buffer = {
     //literal
     0x58, 0x00, 0x00, 0x21,         // ldr x1,  #4
     0x58, 0x00, 0x08, 0x01,         // ldr x1,  #256
     0x18, 0x00, 0x00, 0x21,         // ldr w1,  #4
     0x18, 0x00, 0x08, 0x01,         // ldr w1,  #1048576
-
-    //0xd5,   0x03,   0x20,   0x1f,        //nop
 
     //post-inc
     0xf8, 0x40, 0x14, 0x41,         // ldr,     x1, [x2], #1
@@ -259,1846 +246,829 @@ test_results_t aarch64_decode_ldst_Mutator::executeTest()
     
     0xd5,   0x03,   0x20,   0x1f,        //nop
   };
+  // clang-format on
 
-  unsigned int size = sizeof(buffer);
-  unsigned int expectedInsns = size/4;
+  reverseBuffer(buffer.data(), buffer.size());
+  InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_aarch64);
 
-  //++expectedInsns;
-  reverseBuffer(buffer, size);
-  InstructionDecoder d(buffer, size, Dyninst::Arch_aarch64);
-
-  std::deque<Instruction> decodedInsns;
-  Instruction i;
-  i = d.decode();
-  do
-  {
-    decodedInsns.push_back(i);
-    /*std::cout<<*/i.format()/*<<std::endl*/;
-    i = d.decode();
-  }
-  while(i.isValid());
-
-  if(decodedInsns.size() != expectedInsns)
-  {
-    logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-    for(std::deque<Instruction>::iterator curInsn = decodedInsns.begin();
-	curInsn != decodedInsns.end();
-	++curInsn)
-    {
-        logerror("\t%s\n", curInsn->format().c_str());
+  std::vector<Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+  for(int idx = 0; idx < num_tests; idx++) {
+    Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode test %d\n", idx + 1);
+      return FAILED;
     }
+    decodedInsns.push_back(insn);
+  }
 
+  auto create = [](MachRegister reg) {
+    return boost::make_shared<RegisterAST>(reg);
+  };
+
+  RegisterAST::Ptr x0 = create(aarch64::x0);
+  RegisterAST::Ptr x1 = create(aarch64::x1);
+  RegisterAST::Ptr x2 = create(aarch64::x2);
+  RegisterAST::Ptr x3 = create(aarch64::x3);
+  RegisterAST::Ptr x4 = create(aarch64::x4);
+  RegisterAST::Ptr x5 = create(aarch64::x5);
+  RegisterAST::Ptr x6 = create(aarch64::x6);
+  RegisterAST::Ptr x7 = create(aarch64::x7);
+  RegisterAST::Ptr x8 = create(aarch64::x8);
+  RegisterAST::Ptr x9 = create(aarch64::x9);
+  RegisterAST::Ptr x10 = create(aarch64::x10);
+  RegisterAST::Ptr x11 = create(aarch64::x11);
+  RegisterAST::Ptr x12 = create(aarch64::x12);
+  RegisterAST::Ptr x13 = create(aarch64::x13);
+  RegisterAST::Ptr x14 = create(aarch64::x14);
+  RegisterAST::Ptr x15 = create(aarch64::x15);
+  RegisterAST::Ptr x16 = create(aarch64::x16);
+  RegisterAST::Ptr x17 = create(aarch64::x17);
+  RegisterAST::Ptr x18 = create(aarch64::x18);
+  RegisterAST::Ptr x19 = create(aarch64::x19);
+  RegisterAST::Ptr x20 = create(aarch64::x20);
+  RegisterAST::Ptr x21 = create(aarch64::x21);
+  RegisterAST::Ptr x22 = create(aarch64::x22);
+  RegisterAST::Ptr x23 = create(aarch64::x23);
+  RegisterAST::Ptr x24 = create(aarch64::x24);
+  RegisterAST::Ptr x25 = create(aarch64::x25);
+  RegisterAST::Ptr x26 = create(aarch64::x26);
+  RegisterAST::Ptr x27 = create(aarch64::x27);
+  RegisterAST::Ptr x28 = create(aarch64::x28);
+  RegisterAST::Ptr x29 = create(aarch64::x29);
+  RegisterAST::Ptr x30 = create(aarch64::x30);
+
+  RegisterAST::Ptr w0 = create(aarch64::w0);
+  RegisterAST::Ptr w1 = create(aarch64::w1);
+  RegisterAST::Ptr w2 = create(aarch64::w2);
+  RegisterAST::Ptr w3 = create(aarch64::w3);
+  RegisterAST::Ptr w4 = create(aarch64::w4);
+  RegisterAST::Ptr w5 = create(aarch64::w5);
+  RegisterAST::Ptr w6 = create(aarch64::w6);
+  RegisterAST::Ptr w7 = create(aarch64::w7);
+  RegisterAST::Ptr w8 = create(aarch64::w8);
+  RegisterAST::Ptr w9 = create(aarch64::w9);
+  RegisterAST::Ptr w10 = create(aarch64::w10);
+  RegisterAST::Ptr w11 = create(aarch64::w11);
+  RegisterAST::Ptr w12 = create(aarch64::w12);
+  RegisterAST::Ptr w13 = create(aarch64::w13);
+  RegisterAST::Ptr w14 = create(aarch64::w14);
+  RegisterAST::Ptr w15 = create(aarch64::w15);
+  RegisterAST::Ptr w16 = create(aarch64::w16);
+  RegisterAST::Ptr w17 = create(aarch64::w17);
+  RegisterAST::Ptr w18 = create(aarch64::w18);
+  RegisterAST::Ptr w19 = create(aarch64::w19);
+  RegisterAST::Ptr w20 = create(aarch64::w20);
+  RegisterAST::Ptr w21 = create(aarch64::w21);
+  RegisterAST::Ptr w22 = create(aarch64::w22);
+  RegisterAST::Ptr w23 = create(aarch64::w23);
+  RegisterAST::Ptr w24 = create(aarch64::w24);
+  RegisterAST::Ptr w25 = create(aarch64::w25);
+  RegisterAST::Ptr w26 = create(aarch64::w26);
+  RegisterAST::Ptr w27 = create(aarch64::w27);
+  RegisterAST::Ptr w28 = create(aarch64::w28);
+  RegisterAST::Ptr w29 = create(aarch64::w29);
+  RegisterAST::Ptr w30 = create(aarch64::w30);
+
+  RegisterAST::Ptr q0 = create(aarch64::q0);
+  RegisterAST::Ptr q1 = create(aarch64::q1);
+  RegisterAST::Ptr q2 = create(aarch64::q2);
+  RegisterAST::Ptr q3 = create(aarch64::q3);
+  RegisterAST::Ptr q4 = create(aarch64::q4);
+  RegisterAST::Ptr q5 = create(aarch64::q5);
+  RegisterAST::Ptr q6 = create(aarch64::q6);
+  RegisterAST::Ptr q7 = create(aarch64::q7);
+  RegisterAST::Ptr q8 = create(aarch64::q8);
+  RegisterAST::Ptr q9 = create(aarch64::q9);
+  RegisterAST::Ptr q10 = create(aarch64::q10);
+  RegisterAST::Ptr q11 = create(aarch64::q11);
+  RegisterAST::Ptr q12 = create(aarch64::q12);
+  RegisterAST::Ptr q13 = create(aarch64::q13);
+  RegisterAST::Ptr q14 = create(aarch64::q14);
+  RegisterAST::Ptr q15 = create(aarch64::q15);
+  RegisterAST::Ptr q16 = create(aarch64::q16);
+  RegisterAST::Ptr q17 = create(aarch64::q17);
+  RegisterAST::Ptr q18 = create(aarch64::q18);
+  RegisterAST::Ptr q19 = create(aarch64::q19);
+  RegisterAST::Ptr q20 = create(aarch64::q20);
+  RegisterAST::Ptr q21 = create(aarch64::q21);
+  RegisterAST::Ptr q22 = create(aarch64::q22);
+  RegisterAST::Ptr q23 = create(aarch64::q23);
+  RegisterAST::Ptr q24 = create(aarch64::q24);
+  RegisterAST::Ptr q25 = create(aarch64::q25);
+  RegisterAST::Ptr q26 = create(aarch64::q26);
+  RegisterAST::Ptr q27 = create(aarch64::q27);
+  RegisterAST::Ptr q28 = create(aarch64::q28);
+  RegisterAST::Ptr q29 = create(aarch64::q29);
+  RegisterAST::Ptr q30 = create(aarch64::q30);
+  RegisterAST::Ptr q31 = create(aarch64::q31);
+
+  RegisterAST::Ptr s0 = create(aarch64::s0);
+  RegisterAST::Ptr s1 = create(aarch64::s1);
+  RegisterAST::Ptr s2 = create(aarch64::s2);
+  RegisterAST::Ptr s3 = create(aarch64::s3);
+  RegisterAST::Ptr s4 = create(aarch64::s4);
+  RegisterAST::Ptr s5 = create(aarch64::s5);
+  RegisterAST::Ptr s6 = create(aarch64::s6);
+  RegisterAST::Ptr s7 = create(aarch64::s7);
+  RegisterAST::Ptr s8 = create(aarch64::s8);
+  RegisterAST::Ptr s9 = create(aarch64::s9);
+  RegisterAST::Ptr s10 = create(aarch64::s10);
+  RegisterAST::Ptr s11 = create(aarch64::s11);
+  RegisterAST::Ptr s12 = create(aarch64::s12);
+  RegisterAST::Ptr s13 = create(aarch64::s13);
+  RegisterAST::Ptr s14 = create(aarch64::s14);
+  RegisterAST::Ptr s15 = create(aarch64::s15);
+  RegisterAST::Ptr s16 = create(aarch64::s16);
+  RegisterAST::Ptr s17 = create(aarch64::s17);
+  RegisterAST::Ptr s18 = create(aarch64::s18);
+  RegisterAST::Ptr s19 = create(aarch64::s19);
+  RegisterAST::Ptr s20 = create(aarch64::s20);
+  RegisterAST::Ptr s21 = create(aarch64::s21);
+  RegisterAST::Ptr s22 = create(aarch64::s22);
+  RegisterAST::Ptr s23 = create(aarch64::s23);
+  RegisterAST::Ptr s24 = create(aarch64::s24);
+  RegisterAST::Ptr s25 = create(aarch64::s25);
+  RegisterAST::Ptr s26 = create(aarch64::s26);
+  RegisterAST::Ptr s27 = create(aarch64::s27);
+  RegisterAST::Ptr s28 = create(aarch64::s28);
+  RegisterAST::Ptr s29 = create(aarch64::s29);
+  RegisterAST::Ptr s30 = create(aarch64::s30);
+  RegisterAST::Ptr s31 = create(aarch64::s31);
+
+  RegisterAST::Ptr h0 = create(aarch64::h0);
+  RegisterAST::Ptr h1 = create(aarch64::h1);
+  RegisterAST::Ptr h2 = create(aarch64::h2);
+  RegisterAST::Ptr h3 = create(aarch64::h3);
+  RegisterAST::Ptr h4 = create(aarch64::h4);
+  RegisterAST::Ptr h5 = create(aarch64::h5);
+  RegisterAST::Ptr h6 = create(aarch64::h6);
+  RegisterAST::Ptr h7 = create(aarch64::h7);
+  RegisterAST::Ptr h8 = create(aarch64::h8);
+  RegisterAST::Ptr h9 = create(aarch64::h9);
+  RegisterAST::Ptr h10 = create(aarch64::h10);
+  RegisterAST::Ptr h11 = create(aarch64::h11);
+  RegisterAST::Ptr h12 = create(aarch64::h12);
+  RegisterAST::Ptr h13 = create(aarch64::h13);
+  RegisterAST::Ptr h14 = create(aarch64::h14);
+  RegisterAST::Ptr h15 = create(aarch64::h15);
+  RegisterAST::Ptr h16 = create(aarch64::h16);
+  RegisterAST::Ptr h17 = create(aarch64::h17);
+  RegisterAST::Ptr h18 = create(aarch64::h18);
+  RegisterAST::Ptr h19 = create(aarch64::h19);
+  RegisterAST::Ptr h20 = create(aarch64::h20);
+  RegisterAST::Ptr h21 = create(aarch64::h21);
+  RegisterAST::Ptr h22 = create(aarch64::h22);
+  RegisterAST::Ptr h23 = create(aarch64::h23);
+  RegisterAST::Ptr h24 = create(aarch64::h24);
+  RegisterAST::Ptr h25 = create(aarch64::h25);
+  RegisterAST::Ptr h26 = create(aarch64::h26);
+  RegisterAST::Ptr h27 = create(aarch64::h27);
+  RegisterAST::Ptr h28 = create(aarch64::h28);
+  RegisterAST::Ptr h29 = create(aarch64::h29);
+  RegisterAST::Ptr h30 = create(aarch64::h30);
+  RegisterAST::Ptr h31 = create(aarch64::h31);
+
+  RegisterAST::Ptr d0 = create(aarch64::d0);
+  RegisterAST::Ptr d1 = create(aarch64::d1);
+  RegisterAST::Ptr d2 = create(aarch64::d2);
+  RegisterAST::Ptr d3 = create(aarch64::d3);
+  RegisterAST::Ptr d4 = create(aarch64::d4);
+  RegisterAST::Ptr d5 = create(aarch64::d5);
+  RegisterAST::Ptr d6 = create(aarch64::d6);
+  RegisterAST::Ptr d7 = create(aarch64::d7);
+  RegisterAST::Ptr d8 = create(aarch64::d8);
+  RegisterAST::Ptr d9 = create(aarch64::d9);
+  RegisterAST::Ptr d10 = create(aarch64::d10);
+  RegisterAST::Ptr d11 = create(aarch64::d11);
+  RegisterAST::Ptr d12 = create(aarch64::d12);
+  RegisterAST::Ptr d13 = create(aarch64::d13);
+  RegisterAST::Ptr d14 = create(aarch64::d14);
+  RegisterAST::Ptr d15 = create(aarch64::d15);
+  RegisterAST::Ptr d16 = create(aarch64::d16);
+  RegisterAST::Ptr d17 = create(aarch64::d17);
+  RegisterAST::Ptr d18 = create(aarch64::d18);
+  RegisterAST::Ptr d19 = create(aarch64::d19);
+  RegisterAST::Ptr d20 = create(aarch64::d20);
+  RegisterAST::Ptr d21 = create(aarch64::d21);
+  RegisterAST::Ptr d22 = create(aarch64::d22);
+  RegisterAST::Ptr d23 = create(aarch64::d23);
+  RegisterAST::Ptr d24 = create(aarch64::d24);
+  RegisterAST::Ptr d25 = create(aarch64::d25);
+  RegisterAST::Ptr d26 = create(aarch64::d26);
+  RegisterAST::Ptr d27 = create(aarch64::d27);
+  RegisterAST::Ptr d28 = create(aarch64::d28);
+  RegisterAST::Ptr d29 = create(aarch64::d29);
+  RegisterAST::Ptr d30 = create(aarch64::d30);
+  RegisterAST::Ptr d31 = create(aarch64::d31);
+
+  RegisterAST::Ptr b0 = create(aarch64::b0);
+  RegisterAST::Ptr b1 = create(aarch64::b1);
+  RegisterAST::Ptr b2 = create(aarch64::b2);
+  RegisterAST::Ptr b3 = create(aarch64::b3);
+  RegisterAST::Ptr b4 = create(aarch64::b4);
+  RegisterAST::Ptr b5 = create(aarch64::b5);
+  RegisterAST::Ptr b6 = create(aarch64::b6);
+  RegisterAST::Ptr b7 = create(aarch64::b7);
+  RegisterAST::Ptr b8 = create(aarch64::b8);
+  RegisterAST::Ptr b9 = create(aarch64::b9);
+  RegisterAST::Ptr b10 = create(aarch64::b10);
+  RegisterAST::Ptr b11 = create(aarch64::b11);
+  RegisterAST::Ptr b12 = create(aarch64::b12);
+  RegisterAST::Ptr b13 = create(aarch64::b13);
+  RegisterAST::Ptr b14 = create(aarch64::b14);
+  RegisterAST::Ptr b15 = create(aarch64::b15);
+  RegisterAST::Ptr b16 = create(aarch64::b16);
+  RegisterAST::Ptr b17 = create(aarch64::b17);
+  RegisterAST::Ptr b18 = create(aarch64::b18);
+  RegisterAST::Ptr b19 = create(aarch64::b19);
+  RegisterAST::Ptr b20 = create(aarch64::b20);
+  RegisterAST::Ptr b21 = create(aarch64::b21);
+  RegisterAST::Ptr b22 = create(aarch64::b22);
+  RegisterAST::Ptr b23 = create(aarch64::b23);
+  RegisterAST::Ptr b24 = create(aarch64::b24);
+  RegisterAST::Ptr b25 = create(aarch64::b25);
+  RegisterAST::Ptr b26 = create(aarch64::b26);
+  RegisterAST::Ptr b27 = create(aarch64::b27);
+  RegisterAST::Ptr b28 = create(aarch64::b28);
+  RegisterAST::Ptr b29 = create(aarch64::b29);
+  RegisterAST::Ptr b30 = create(aarch64::b30);
+  RegisterAST::Ptr b31 = create(aarch64::b31);
+
+  RegisterAST::Ptr xzr = create(aarch64::xzr);
+  RegisterAST::Ptr wzr = create(aarch64::wzr);
+  RegisterAST::Ptr sp = create(aarch64::sp);
+  RegisterAST::Ptr wsp = create(aarch64::wsp);
+  RegisterAST::Ptr pc = create(aarch64::pc);
+  RegisterAST::Ptr nzcv = create(aarch64::nzcv);
+
+  std::vector<registerSet> expectedRead, expectedWritten;
+
+  // ldr x1, #4
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({x1});
+
+  // ldr x1, #256
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({x1});
+
+  // ldr w1, #4
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({w1});
+
+  // ldr w1, #1048576
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({w1});
+
+  // ldr, x1, [x2], #1
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldr, x1, [x2], #255
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldrb, w1, [x2], #1
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsb, w1, [x2], #1
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrh, w1, [x2], #1
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsh, x1, [x2], #1
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldr, x1, [x2, #8]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldr, x1, [x2, #256]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldrb, w1, [x2, #4]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsb, w1, [x2, #4]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrh, w1, [x2, #4]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsh, w1, [x2, #4]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsw, x1, [x2, #4]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldr, x1, [x2, x3]
+  expectedRead.push_back({x2, x3});
+  expectedWritten.push_back({x1});
+
+  // ldrb, w1, [x2, x3]
+  expectedRead.push_back({x2, x3});
+  expectedWritten.push_back({w1});
+
+  // ldrsb, w1, [x2, x3]
+  expectedRead.push_back({x2, x3});
+  expectedWritten.push_back({w1});
+
+  // ldrh, w1, [x2, x3]
+  expectedRead.push_back({x2, x3});
+  expectedWritten.push_back({w1});
+
+  // ldrsh, w1, [x2, x3]
+  expectedRead.push_back({x2, x3});
+  expectedWritten.push_back({w1});
+
+  // ldrsw, x1, [x2, x3]
+  expectedRead.push_back({x2, x3});
+  expectedWritten.push_back({x1});
+
+  // ldr, x1, [x2, #1]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldr, x1, [x2, #255]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldrb, w1, [x2, #1]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsb, w1, [x2, #1]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrh, w1, [x2, #1]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsh, w1, [x2, #1]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldrsw, x1, [x2, #1]!
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldar x1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldar w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldxrb w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldaxrb w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldarb w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldxrh w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldaxrh w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldarh w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldxr x1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldaxr x1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldar x1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1});
+
+  // ldxr w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldaxr w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldar w1, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1});
+
+  // ldxp x1, x3, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1, x3});
+
+  // ldaxp x1, x3, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({x1, x3});
+
+  // ldxp w1, w3, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1, w3});
+
+  // ldaxp w1, w3, [x2]
+  expectedRead.push_back({x2});
+  expectedWritten.push_back({w1, w3});
+
+  // ldnp x1, x2, [x3,#8]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1, x2});
+
+  // ldp x1, x2, [x3,#8]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1, x2});
+
+  // ldp x1, x2, [x3,#8]!
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1, x2});
+
+  // ldp x1, x2, [x3],#8
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1, x2});
+
+  // ldp x1, x2, [x3],#8
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1, x2});
+
+  // ldurb w1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({w1});
+
+  // ldursb x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldur x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldurh w1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({w1});
+
+  // ldursh x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldursw x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldtrb w1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({w1});
+
+  // ldtrsb x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldtr x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldtrh w1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({w1});
+
+  // ldtrsh x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // ldtrsw x1, [x3,#1]
+  expectedRead.push_back({x3});
+  expectedWritten.push_back({x1});
+
+  // str x1, [x2],#1
+  expectedRead.push_back({x2, x1});
+  expectedWritten.push_back({});
+
+  // str x1, [x2],#255
+  expectedRead.push_back({x2, x1});
+  expectedWritten.push_back({});
+
+  // strb w1, [x2],#1
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({});
+
+  // strh w1, [x2],#1
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({});
+
+  // str x1, [x2,#8]
+  expectedRead.push_back({x2, x1});
+  expectedWritten.push_back({});
+
+  // str x1, [x2,#256]
+  expectedRead.push_back({x2, x1});
+  expectedWritten.push_back({});
+
+  // strb w1, [x2,#4]
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({});
+
+  // strh w1, [x2,#4]
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({});
+
+  // str x1, [x2,x3]
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // str x1, [x2,x3]
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // strb w1, [x2,x3]
+  expectedRead.push_back({x2, w1, x3});
+  expectedWritten.push_back({});
+
+  // strh w1, [x2,x3]
+  expectedRead.push_back({x2, w1, x3});
+  expectedWritten.push_back({});
+
+  // str x1, [x2,#1]!
+  expectedRead.push_back({x2, x1});
+  expectedWritten.push_back({});
+
+  // str x1, [x2,#255]!
+  expectedRead.push_back({x2, x1});
+  expectedWritten.push_back({});
+
+  // strb w1, [x2,#1]!
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({});
+
+  // strh w1, [x2,#1]!
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({});
+
+  // stxrb w0, w1, [x2]
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({w0});
+
+  // stxrh w0, w1, [x2]
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({w0});
+
+  // stxr w0, w1, [x2]
+  expectedRead.push_back({x2, w1});
+  expectedWritten.push_back({w0});
+
+  // stxp w0, w1, w3, [x2]
+  expectedRead.push_back({x2, w1, w3});
+  expectedWritten.push_back({w0});
+
+  // stnp x1, x2, [x3,#8]
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // stp x1, x2, [x3,#8]
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // stp x1, x2, [x3,#8]!
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // stp x1, x2, [x3],#8
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // stp x1, x2, [x3],#8
+  expectedRead.push_back({x2, x1, x3});
+  expectedWritten.push_back({});
+
+  // sturb w1, [x3,#1]
+  expectedRead.push_back({x3, w1});
+  expectedWritten.push_back({});
+
+  // str x1, [x3,#1]
+  expectedRead.push_back({x3, x1});
+  expectedWritten.push_back({});
+
+  // strh w1, [x3,#1]
+  expectedRead.push_back({x3, w1});
+  expectedWritten.push_back({});
+
+  // sttr x1, [x3,#1]
+  expectedRead.push_back({x3, x1});
+  expectedWritten.push_back({});
+
+  // sttrb w1, [x3,#1]
+  expectedRead.push_back({x3, w1});
+  expectedWritten.push_back({});
+
+  // sttrh w1, [x3,#1]
+  expectedRead.push_back({x3, w1});
+  expectedWritten.push_back({});
+
+  // stlrb w1, [x3]
+  expectedRead.push_back({x3, w1});
+  expectedWritten.push_back({});
+
+  // stlr x1, [x3]
+  expectedRead.push_back({x3, x1});
+  expectedWritten.push_back({});
+
+  // stlrh w1, [x3]
+  expectedRead.push_back({x3, w1});
+  expectedWritten.push_back({});
+
+  // stlxp w0, x1, x2, [x3]
+  expectedRead.push_back({x3, x1, x2});
+  expectedWritten.push_back({w0});
+
+  // stlxrb w0, w1, [x3]
+  expectedRead.push_back({w1, x3});
+  expectedWritten.push_back({w0});
+
+  // stlxr w0, x1, [x3]
+  expectedRead.push_back({x1, x3});
+  expectedWritten.push_back({w0});
+
+  // stlxrh w0, w1, [x3]
+  expectedRead.push_back({w1, x3});
+  expectedWritten.push_back({w0});
+
+  // ldr x1, [x2,x3]
+  expectedRead.push_back({x3, x2});
+  expectedWritten.push_back({x1});
+
+  // ldr x1, [x2,x3,lsl #3]
+  expectedRead.push_back({x3, x2});
+  expectedWritten.push_back({x1});
+
+  // ldr w1, [x2,x3,lsl #2]
+  expectedRead.push_back({x3, x2});
+  expectedWritten.push_back({w1});
+
+  // ldr x1, [x2,w3,uxtw]
+  expectedRead.push_back({w3, x2});
+  expectedWritten.push_back({x1});
+
+  // ldr x1, [x2,x3,sxtx]
+  expectedRead.push_back({x3, x2});
+  expectedWritten.push_back({x1});
+
+  // csinc x0, x1, x2, eq
+  expectedRead.push_back({x1, x2, nzcv});
+  expectedWritten.push_back({x0});
+
+  // csinv x0, x1, x2, eq
+  expectedRead.push_back({x1, x2, nzcv});
+  expectedWritten.push_back({x0});
+
+  // csneg x0, x1, x2, eq
+  expectedRead.push_back({x1, x2, nzcv});
+  expectedWritten.push_back({x0});
+
+  // ubfiz x0, x1, #1, #1
+  expectedRead.push_back({x1});
+  expectedWritten.push_back({x0});
+
+  // lsr w0, w1, #0
+  expectedRead.push_back({w1});
+  expectedWritten.push_back({w0});
+
+  // mov x0, #0xffffffffffff0000
+  expectedRead.push_back({});
+  expectedWritten.push_back({x0});
+
+  // mov x0, #0xffffffffffff
+  expectedRead.push_back({});
+  expectedWritten.push_back({x0});
+
+  // movn w0, #0xffff, lsl #16
+  expectedRead.push_back({});
+  expectedWritten.push_back({w0});
+
+  // mov x0, #0xffff
+  expectedRead.push_back({});
+  expectedWritten.push_back({x0});
+
+  // mov x0, #0xffff000000000000
+  expectedRead.push_back({});
+  expectedWritten.push_back({x0});
+
+  // mov w0, #0xffff0000
+  expectedRead.push_back({});
+  expectedWritten.push_back({w0});
+
+  // ldr w30, 500630 0xffff4
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({w30});
+
+  // ldr x30, 3e7fa0 -0x184d0
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({x30});
+
+  // ldr w15, [x0],#255
+  expectedRead.push_back({x0});
+  expectedWritten.push_back({w15});
+
+  // ldr x15, [x30],#-240
+  expectedRead.push_back({x30});
+  expectedWritten.push_back({x15});
+
+  // ldr w29, [sp,#16380]
+  expectedRead.push_back({sp});
+  expectedWritten.push_back({w29});
+
+  // ldr x29, [sp,#32760]
+  expectedRead.push_back({sp});
+  expectedWritten.push_back({x29});
+
+  // ldr x1, [x2,x31]
+  expectedRead.push_back({x2, xzr});
+  expectedWritten.push_back({x1});
+
+  // ldr x1, [sp,#255]!
+  expectedRead.push_back({sp});
+  expectedWritten.push_back({x1});
+
+  // prfm 1F, [pc + 4]
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({});
+
+  // prfm 0, [pc + fffffffffffffffc]
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({});
+
+  // prfm 8, [pc + 1fb00]
+  expectedRead.push_back({pc});
+  expectedWritten.push_back({});
+
+  // prfm 1d, [x1 + 8]
+  expectedRead.push_back({x1});
+  expectedWritten.push_back({});
+
+  // prfm 1f, [x30 + 7ff8]
+  expectedRead.push_back({x30});
+  expectedWritten.push_back({});
+
+  // prfm 4, [x2 + x5 << 0]
+  expectedRead.push_back({x2, x5});
+  expectedWritten.push_back({});
+
+  // prfm 5, [x30 + w1 << 3]
+  expectedRead.push_back({x30, w1});
+  expectedWritten.push_back({});
+
+  // prfm 6, [x8 + x5 << 0]
+  expectedRead.push_back({x8, x5});
+  expectedWritten.push_back({});
+
+  // nop
+  expectedRead.push_back({});
+  expectedWritten.push_back({});
+
+  if(expectedRead.size() != expectedWritten.size()) {
+    logerror("FATAL: expectedRead.size() != expectedWritten.size()");
     return FAILED;
   }
 
-  /*if(decodedInsns.back().isValid())
-  {
-    logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
+  if(expectedRead.size() != decodedInsns.size()) {
+    logerror("FATAL: expectedRead.size() != decodedInsns.size()");
     return FAILED;
-  }*/
-
-  RegisterAST::Ptr x0 (new RegisterAST(aarch64::x0));
-  RegisterAST::Ptr x1 (new RegisterAST(aarch64::x1));
-  RegisterAST::Ptr x2 (new RegisterAST(aarch64::x2));
-  RegisterAST::Ptr x3 (new RegisterAST(aarch64::x3));
-  RegisterAST::Ptr x4 (new RegisterAST(aarch64::x4));
-  RegisterAST::Ptr x5 (new RegisterAST(aarch64::x5));
-  RegisterAST::Ptr x6 (new RegisterAST(aarch64::x6));
-  RegisterAST::Ptr x7 (new RegisterAST(aarch64::x7));
-  RegisterAST::Ptr x8 (new RegisterAST(aarch64::x8));
-  RegisterAST::Ptr x9 (new RegisterAST(aarch64::x9));
-  RegisterAST::Ptr x10(new RegisterAST(aarch64::x10));
-  RegisterAST::Ptr x11(new RegisterAST(aarch64::x11));
-  RegisterAST::Ptr x12(new RegisterAST(aarch64::x12));
-  RegisterAST::Ptr x13(new RegisterAST(aarch64::x13));
-  RegisterAST::Ptr x14(new RegisterAST(aarch64::x14));
-  RegisterAST::Ptr x15(new RegisterAST(aarch64::x15));
-  RegisterAST::Ptr x16(new RegisterAST(aarch64::x16));
-  RegisterAST::Ptr x17(new RegisterAST(aarch64::x17));
-  RegisterAST::Ptr x18(new RegisterAST(aarch64::x18));
-  RegisterAST::Ptr x19(new RegisterAST(aarch64::x19));
-  RegisterAST::Ptr x20(new RegisterAST(aarch64::x20));
-  RegisterAST::Ptr x21(new RegisterAST(aarch64::x21));
-  RegisterAST::Ptr x22(new RegisterAST(aarch64::x22));
-  RegisterAST::Ptr x23(new RegisterAST(aarch64::x23));
-  RegisterAST::Ptr x24(new RegisterAST(aarch64::x24));
-  RegisterAST::Ptr x25(new RegisterAST(aarch64::x25));
-  RegisterAST::Ptr x26(new RegisterAST(aarch64::x26));
-  RegisterAST::Ptr x27(new RegisterAST(aarch64::x27));
-  RegisterAST::Ptr x28(new RegisterAST(aarch64::x28));
-  RegisterAST::Ptr x29(new RegisterAST(aarch64::x29));
-  RegisterAST::Ptr x30(new RegisterAST(aarch64::x30));
-
-  RegisterAST::Ptr w0 (new RegisterAST(aarch64::w0));
-  RegisterAST::Ptr w1 (new RegisterAST(aarch64::w1));
-  RegisterAST::Ptr w2 (new RegisterAST(aarch64::w2));
-  RegisterAST::Ptr w3 (new RegisterAST(aarch64::w3));
-  RegisterAST::Ptr w4 (new RegisterAST(aarch64::w4));
-  RegisterAST::Ptr w5 (new RegisterAST(aarch64::w5));
-  RegisterAST::Ptr w6 (new RegisterAST(aarch64::w6));
-  RegisterAST::Ptr w7 (new RegisterAST(aarch64::w7));
-  RegisterAST::Ptr w8 (new RegisterAST(aarch64::w8));
-  RegisterAST::Ptr w9 (new RegisterAST(aarch64::w9));
-  RegisterAST::Ptr w10(new RegisterAST(aarch64::w10));
-  RegisterAST::Ptr w11(new RegisterAST(aarch64::w11));
-  RegisterAST::Ptr w12(new RegisterAST(aarch64::w12));
-  RegisterAST::Ptr w13(new RegisterAST(aarch64::w13));
-  RegisterAST::Ptr w14(new RegisterAST(aarch64::w14));
-  RegisterAST::Ptr w15(new RegisterAST(aarch64::w15));
-  RegisterAST::Ptr w16(new RegisterAST(aarch64::w16));
-  RegisterAST::Ptr w17(new RegisterAST(aarch64::w17));
-  RegisterAST::Ptr w18(new RegisterAST(aarch64::w18));
-  RegisterAST::Ptr w19(new RegisterAST(aarch64::w19));
-  RegisterAST::Ptr w20(new RegisterAST(aarch64::w20));
-  RegisterAST::Ptr w21(new RegisterAST(aarch64::w21));
-  RegisterAST::Ptr w22(new RegisterAST(aarch64::w22));
-  RegisterAST::Ptr w23(new RegisterAST(aarch64::w23));
-  RegisterAST::Ptr w24(new RegisterAST(aarch64::w24));
-  RegisterAST::Ptr w25(new RegisterAST(aarch64::w25));
-  RegisterAST::Ptr w26(new RegisterAST(aarch64::w26));
-  RegisterAST::Ptr w27(new RegisterAST(aarch64::w27));
-  RegisterAST::Ptr w28(new RegisterAST(aarch64::w28));
-  RegisterAST::Ptr w29(new RegisterAST(aarch64::w29));
-  RegisterAST::Ptr w30(new RegisterAST(aarch64::w30));
-
-  RegisterAST::Ptr q0 (new RegisterAST(aarch64::q0));
-  RegisterAST::Ptr q1 (new RegisterAST(aarch64::q1));
-  RegisterAST::Ptr q2 (new RegisterAST(aarch64::q2));
-  RegisterAST::Ptr q3 (new RegisterAST(aarch64::q3));
-  RegisterAST::Ptr q4 (new RegisterAST(aarch64::q4));
-  RegisterAST::Ptr q5 (new RegisterAST(aarch64::q5));
-  RegisterAST::Ptr q6 (new RegisterAST(aarch64::q6));
-  RegisterAST::Ptr q7 (new RegisterAST(aarch64::q7));
-  RegisterAST::Ptr q8 (new RegisterAST(aarch64::q8));
-  RegisterAST::Ptr q9 (new RegisterAST(aarch64::q9));
-  RegisterAST::Ptr q10(new RegisterAST(aarch64::q10));
-  RegisterAST::Ptr q11(new RegisterAST(aarch64::q11));
-  RegisterAST::Ptr q12(new RegisterAST(aarch64::q12));
-  RegisterAST::Ptr q13(new RegisterAST(aarch64::q13));
-  RegisterAST::Ptr q14(new RegisterAST(aarch64::q14));
-  RegisterAST::Ptr q15(new RegisterAST(aarch64::q15));
-  RegisterAST::Ptr q16(new RegisterAST(aarch64::q16));
-  RegisterAST::Ptr q17(new RegisterAST(aarch64::q17));
-  RegisterAST::Ptr q18(new RegisterAST(aarch64::q18));
-  RegisterAST::Ptr q19(new RegisterAST(aarch64::q19));
-  RegisterAST::Ptr q20(new RegisterAST(aarch64::q20));
-  RegisterAST::Ptr q21(new RegisterAST(aarch64::q21));
-  RegisterAST::Ptr q22(new RegisterAST(aarch64::q22));
-  RegisterAST::Ptr q23(new RegisterAST(aarch64::q23));
-  RegisterAST::Ptr q24(new RegisterAST(aarch64::q24));
-  RegisterAST::Ptr q25(new RegisterAST(aarch64::q25));
-  RegisterAST::Ptr q26(new RegisterAST(aarch64::q26));
-  RegisterAST::Ptr q27(new RegisterAST(aarch64::q27));
-  RegisterAST::Ptr q28(new RegisterAST(aarch64::q28));
-  RegisterAST::Ptr q29(new RegisterAST(aarch64::q29));
-  RegisterAST::Ptr q30(new RegisterAST(aarch64::q30));
-  RegisterAST::Ptr q31(new RegisterAST(aarch64::q31));
-
-  RegisterAST::Ptr s0 (new RegisterAST(aarch64::s0));
-  RegisterAST::Ptr s1 (new RegisterAST(aarch64::s1));
-  RegisterAST::Ptr s2 (new RegisterAST(aarch64::s2));
-  RegisterAST::Ptr s3 (new RegisterAST(aarch64::s3));
-  RegisterAST::Ptr s4 (new RegisterAST(aarch64::s4));
-  RegisterAST::Ptr s5 (new RegisterAST(aarch64::s5));
-  RegisterAST::Ptr s6 (new RegisterAST(aarch64::s6));
-  RegisterAST::Ptr s7 (new RegisterAST(aarch64::s7));
-  RegisterAST::Ptr s8 (new RegisterAST(aarch64::s8));
-  RegisterAST::Ptr s9 (new RegisterAST(aarch64::s9));
-  RegisterAST::Ptr s10(new RegisterAST(aarch64::s10));
-  RegisterAST::Ptr s11(new RegisterAST(aarch64::s11));
-  RegisterAST::Ptr s12(new RegisterAST(aarch64::s12));
-  RegisterAST::Ptr s13(new RegisterAST(aarch64::s13));
-  RegisterAST::Ptr s14(new RegisterAST(aarch64::s14));
-  RegisterAST::Ptr s15(new RegisterAST(aarch64::s15));
-  RegisterAST::Ptr s16(new RegisterAST(aarch64::s16));
-  RegisterAST::Ptr s17(new RegisterAST(aarch64::s17));
-  RegisterAST::Ptr s18(new RegisterAST(aarch64::s18));
-  RegisterAST::Ptr s19(new RegisterAST(aarch64::s19));
-  RegisterAST::Ptr s20(new RegisterAST(aarch64::s20));
-  RegisterAST::Ptr s21(new RegisterAST(aarch64::s21));
-  RegisterAST::Ptr s22(new RegisterAST(aarch64::s22));
-  RegisterAST::Ptr s23(new RegisterAST(aarch64::s23));
-  RegisterAST::Ptr s24(new RegisterAST(aarch64::s24));
-  RegisterAST::Ptr s25(new RegisterAST(aarch64::s25));
-  RegisterAST::Ptr s26(new RegisterAST(aarch64::s26));
-  RegisterAST::Ptr s27(new RegisterAST(aarch64::s27));
-  RegisterAST::Ptr s28(new RegisterAST(aarch64::s28));
-  RegisterAST::Ptr s29(new RegisterAST(aarch64::s29));
-  RegisterAST::Ptr s30(new RegisterAST(aarch64::s30));
-  RegisterAST::Ptr s31(new RegisterAST(aarch64::s31));
-
-  RegisterAST::Ptr h0 (new RegisterAST(aarch64::h0));
-  RegisterAST::Ptr h1 (new RegisterAST(aarch64::h1));
-  RegisterAST::Ptr h2 (new RegisterAST(aarch64::h2));
-  RegisterAST::Ptr h3 (new RegisterAST(aarch64::h3));
-  RegisterAST::Ptr h4 (new RegisterAST(aarch64::h4));
-  RegisterAST::Ptr h5 (new RegisterAST(aarch64::h5));
-  RegisterAST::Ptr h6 (new RegisterAST(aarch64::h6));
-  RegisterAST::Ptr h7 (new RegisterAST(aarch64::h7));
-  RegisterAST::Ptr h8 (new RegisterAST(aarch64::h8));
-  RegisterAST::Ptr h9 (new RegisterAST(aarch64::h9));
-  RegisterAST::Ptr h10(new RegisterAST(aarch64::h10));
-  RegisterAST::Ptr h11(new RegisterAST(aarch64::h11));
-  RegisterAST::Ptr h12(new RegisterAST(aarch64::h12));
-  RegisterAST::Ptr h13(new RegisterAST(aarch64::h13));
-  RegisterAST::Ptr h14(new RegisterAST(aarch64::h14));
-  RegisterAST::Ptr h15(new RegisterAST(aarch64::h15));
-  RegisterAST::Ptr h16(new RegisterAST(aarch64::h16));
-  RegisterAST::Ptr h17(new RegisterAST(aarch64::h17));
-  RegisterAST::Ptr h18(new RegisterAST(aarch64::h18));
-  RegisterAST::Ptr h19(new RegisterAST(aarch64::h19));
-  RegisterAST::Ptr h20(new RegisterAST(aarch64::h20));
-  RegisterAST::Ptr h21(new RegisterAST(aarch64::h21));
-  RegisterAST::Ptr h22(new RegisterAST(aarch64::h22));
-  RegisterAST::Ptr h23(new RegisterAST(aarch64::h23));
-  RegisterAST::Ptr h24(new RegisterAST(aarch64::h24));
-  RegisterAST::Ptr h25(new RegisterAST(aarch64::h25));
-  RegisterAST::Ptr h26(new RegisterAST(aarch64::h26));
-  RegisterAST::Ptr h27(new RegisterAST(aarch64::h27));
-  RegisterAST::Ptr h28(new RegisterAST(aarch64::h28));
-  RegisterAST::Ptr h29(new RegisterAST(aarch64::h29));
-  RegisterAST::Ptr h30(new RegisterAST(aarch64::h30));
-  RegisterAST::Ptr h31(new RegisterAST(aarch64::h31));
-
-  RegisterAST::Ptr d0 (new RegisterAST(aarch64::d0));
-  RegisterAST::Ptr d1 (new RegisterAST(aarch64::d1));
-  RegisterAST::Ptr d2 (new RegisterAST(aarch64::d2));
-  RegisterAST::Ptr d3 (new RegisterAST(aarch64::d3));
-  RegisterAST::Ptr d4 (new RegisterAST(aarch64::d4));
-  RegisterAST::Ptr d5 (new RegisterAST(aarch64::d5));
-  RegisterAST::Ptr d6 (new RegisterAST(aarch64::d6));
-  RegisterAST::Ptr d7 (new RegisterAST(aarch64::d7));
-  RegisterAST::Ptr d8 (new RegisterAST(aarch64::d8));
-  RegisterAST::Ptr d9 (new RegisterAST(aarch64::d9));
-  RegisterAST::Ptr d10(new RegisterAST(aarch64::d10));
-  RegisterAST::Ptr d11(new RegisterAST(aarch64::d11));
-  RegisterAST::Ptr d12(new RegisterAST(aarch64::d12));
-  RegisterAST::Ptr d13(new RegisterAST(aarch64::d13));
-  RegisterAST::Ptr d14(new RegisterAST(aarch64::d14));
-  RegisterAST::Ptr d15(new RegisterAST(aarch64::d15));
-  RegisterAST::Ptr d16(new RegisterAST(aarch64::d16));
-  RegisterAST::Ptr d17(new RegisterAST(aarch64::d17));
-  RegisterAST::Ptr d18(new RegisterAST(aarch64::d18));
-  RegisterAST::Ptr d19(new RegisterAST(aarch64::d19));
-  RegisterAST::Ptr d20(new RegisterAST(aarch64::d20));
-  RegisterAST::Ptr d21(new RegisterAST(aarch64::d21));
-  RegisterAST::Ptr d22(new RegisterAST(aarch64::d22));
-  RegisterAST::Ptr d23(new RegisterAST(aarch64::d23));
-  RegisterAST::Ptr d24(new RegisterAST(aarch64::d24));
-  RegisterAST::Ptr d25(new RegisterAST(aarch64::d25));
-  RegisterAST::Ptr d26(new RegisterAST(aarch64::d26));
-  RegisterAST::Ptr d27(new RegisterAST(aarch64::d27));
-  RegisterAST::Ptr d28(new RegisterAST(aarch64::d28));
-  RegisterAST::Ptr d29(new RegisterAST(aarch64::d29));
-  RegisterAST::Ptr d30(new RegisterAST(aarch64::d30));
-  RegisterAST::Ptr d31(new RegisterAST(aarch64::d31));
-
-  RegisterAST::Ptr b0 (new RegisterAST(aarch64::b0));
-  RegisterAST::Ptr b1 (new RegisterAST(aarch64::b1));
-  RegisterAST::Ptr b2 (new RegisterAST(aarch64::b2));
-  RegisterAST::Ptr b3 (new RegisterAST(aarch64::b3));
-  RegisterAST::Ptr b4 (new RegisterAST(aarch64::b4));
-  RegisterAST::Ptr b5 (new RegisterAST(aarch64::b5));
-  RegisterAST::Ptr b6 (new RegisterAST(aarch64::b6));
-  RegisterAST::Ptr b7 (new RegisterAST(aarch64::b7));
-  RegisterAST::Ptr b8 (new RegisterAST(aarch64::b8));
-  RegisterAST::Ptr b9 (new RegisterAST(aarch64::b9));
-  RegisterAST::Ptr b10(new RegisterAST(aarch64::b10));
-  RegisterAST::Ptr b11(new RegisterAST(aarch64::b11));
-  RegisterAST::Ptr b12(new RegisterAST(aarch64::b12));
-  RegisterAST::Ptr b13(new RegisterAST(aarch64::b13));
-  RegisterAST::Ptr b14(new RegisterAST(aarch64::b14));
-  RegisterAST::Ptr b15(new RegisterAST(aarch64::b15));
-  RegisterAST::Ptr b16(new RegisterAST(aarch64::b16));
-  RegisterAST::Ptr b17(new RegisterAST(aarch64::b17));
-  RegisterAST::Ptr b18(new RegisterAST(aarch64::b18));
-  RegisterAST::Ptr b19(new RegisterAST(aarch64::b19));
-  RegisterAST::Ptr b20(new RegisterAST(aarch64::b20));
-  RegisterAST::Ptr b21(new RegisterAST(aarch64::b21));
-  RegisterAST::Ptr b22(new RegisterAST(aarch64::b22));
-  RegisterAST::Ptr b23(new RegisterAST(aarch64::b23));
-  RegisterAST::Ptr b24(new RegisterAST(aarch64::b24));
-  RegisterAST::Ptr b25(new RegisterAST(aarch64::b25));
-  RegisterAST::Ptr b26(new RegisterAST(aarch64::b26));
-  RegisterAST::Ptr b27(new RegisterAST(aarch64::b27));
-  RegisterAST::Ptr b28(new RegisterAST(aarch64::b28));
-  RegisterAST::Ptr b29(new RegisterAST(aarch64::b29));
-  RegisterAST::Ptr b30(new RegisterAST(aarch64::b30));
-  RegisterAST::Ptr b31(new RegisterAST(aarch64::b31));
-
-  RegisterAST::Ptr zr (new RegisterAST(aarch64::xzr));
-  RegisterAST::Ptr wzr (new RegisterAST(aarch64::wzr));
-  RegisterAST::Ptr sp (new RegisterAST(aarch64::sp));
-  RegisterAST::Ptr wsp (new RegisterAST(aarch64::wsp));
-  RegisterAST::Ptr pc (new RegisterAST(aarch64::pc));
-  RegisterAST::Ptr nzcv (new RegisterAST(aarch64::nzcv));
-
-  std::deque<registerSet> expectedRead, expectedWritten;
-  registerSet tmpRead, tmpWritten;
+  }
 
   test_results_t retVal = PASSED;
+  for(auto&& x : boost::combine(decodedInsns, expectedRead, expectedWritten)) {
+    auto insn = x.get<0>();
+    auto read = x.get<1>();
+    auto written = x.get<2>();
 
-  //ldr x1, #4
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(pc);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// ldr x1, #256
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(pc);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// ldr w1, #4
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(pc);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// ldr w1, #256
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(pc);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// post-inc
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// imm
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// reg offset not ext
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// pre inc
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// ex
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1, x3};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1)(x3);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {x1, x3};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(x1)(x3);
-#endif
-
-//
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1, w3};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1)(w3);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2};
-	tmpWritten = {w1, w3};
-#else
-	tmpRead = list_of(x2);
-	tmpWritten = list_of(w1)(w3);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// pair
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1, x2};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1)(x2);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1, x2};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1)(x2);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1, x2};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1)(x2);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1, x2};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1)(x2);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1, x2};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1)(x2);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// unscaled
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// unpre
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// store 155
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)( w1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//161
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 166
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1,x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 171
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(w1);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 176
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(x2)(w1);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(x2)(w1);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(x2)(w1);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, w1, w3};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(x2)(w1)(w3);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//  181
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x1, x3};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x2)(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 187
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 191
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 195
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(x1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, w1};
-	tmpWritten = {};
-#else
-	tmpRead = list_of(w1)(x3);
-	//tmpWritten = list_of();
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 198
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x1, x2};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(x1)(x2)(x3);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {w1, x3};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(w1)(x3);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x1, x3};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(x1)(x3);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {w1, x3};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(w1)(x3);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//203
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x2};
-	tmpWritten = {w1};
-#else
-	tmpRead = list_of(x2)(x3);
-	tmpWritten = list_of(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {w3, x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(w3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//208
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x3, x2};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(w3);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x1, x2, nzcv};
-	tmpWritten = {x0};
-#else
-	tmpRead = list_of(x2)(x1)(nzcv);
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x1, x2, nzcv};
-	tmpWritten = {x0};
-#else
-	tmpRead = list_of(x2)(x1)(nzcv);
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x1, x2, nzcv};
-	tmpWritten = {x0};
-#else
-	tmpRead = list_of(x2)(x1)(nzcv);
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//213
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x1};
-	tmpWritten = {x0};
-#else
-	tmpRead = list_of(x1);
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {w1};
-	tmpWritten = {w0};
-#else
-	tmpRead = list_of(w1);
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {};
-	tmpWritten = {x0};
-#else
-	//tmpRead = list_of();
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {};
-	tmpWritten = {x0};
-#else
-	//tmpRead = list_of();
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-//218
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {};
-	tmpWritten = {w0};
-#else
-	//tmpRead = list_of();
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {};
-	tmpWritten = {x0};
-#else
-	//tmpRead = list_of();
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {};
-	tmpWritten = {x0};
-#else
-	//tmpRead = list_of();
-	tmpWritten = list_of(x0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {};
-	tmpWritten = {w0};
-#else
-	//tmpRead = list_of();
-	tmpWritten = list_of(w0);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// 223
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-	tmpWritten = {w30};
-#else
-	tmpRead = list_of(pc);
-	tmpWritten = list_of(w30);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-	tmpWritten = {x30};
-#else
-	tmpRead = list_of(pc);
-	tmpWritten = list_of(x30);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x0};
-	tmpWritten = {w15};
-#else
-	tmpRead = list_of(x0);
-	tmpWritten = list_of(w15);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x30};
-	tmpWritten = {x15};
-#else
-	tmpRead = list_of(x30);
-	tmpWritten = list_of(x15);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-
-// 228
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {sp};
-	tmpWritten = {w29};
-#else
-	tmpRead = list_of(sp);
-	tmpWritten = list_of(w29);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {sp};
-	tmpWritten = {x29};
-#else
-	tmpRead = list_of(sp);
-	tmpWritten = list_of(x29);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, zr};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(x2)(zr);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {sp};
-	tmpWritten = {x1};
-#else
-	tmpRead = list_of(sp);
-	tmpWritten = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-#else
-	tmpRead = list_of(pc);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-#else
-	tmpRead = list_of(pc);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {pc};
-#else
-	tmpRead = list_of(pc);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x1};
-#else
-	tmpRead = list_of(x1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x30};
-#else
-	tmpRead = list_of(x30);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x2, x5};
-#else
-	tmpRead = list_of(x2)(x5);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x30, w1};
-#else
-	tmpRead = list_of(x30)(w1);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-	tmpRead = {x8, x5};
-#else
-	tmpRead = list_of(x8)(x5);
-#endif
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-// nop
-expectedRead.push_back(tmpRead);
-expectedWritten.push_back(tmpWritten);
-tmpRead.clear();
-tmpWritten.clear();
-
-  decodedInsns.pop_back();
-  while(!decodedInsns.empty())
-  {
-      retVal = failure_accumulator(retVal, verify_read_write_sets(decodedInsns.front(), expectedRead.front(),
-                                   expectedWritten.front()));
-//      cout<<decodedInsns.front()->format()<<" "<<retVal<<endl;
-      decodedInsns.pop_front();
-
-  	  expectedRead.pop_front();
-      expectedWritten.pop_front();
+    auto status = verify_read_write_sets(insn, read, written);
+    if(status == FAILED) {
+      retVal = FAILED;
+    }
   }
 
   return retVal;
 }
-

--- a/src/instruction/aarch64_simd.C
+++ b/src/instruction/aarch64_simd.C
@@ -28,460 +28,463 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "instruction_comp.h"
-#include "test_lib.h"
-
 #include "Instruction.h"
+#include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
 #include "registers/aarch64_regs.h"
+#include "test_lib.h"
 
-#include <deque>
-#include <vector>
 #include <array>
-#include <algorithm>
+#include <boost/range/combine.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <deque>
 
 using namespace Dyninst;
 using namespace InstructionAPI;
 
-class aarch64_simd_Mutator: public InstructionMutator {
-private:
-  void setupRegisters();
+class aarch64_simd_Mutator : public InstructionMutator {
 public:
   aarch64_simd_Mutator() {}
-  virtual test_results_t executeTest();
+
+  virtual test_results_t executeTest() override;
 };
 
 extern "C" DLLEXPORT TestMutator* aarch64_simd_factory() {
   return new aarch64_simd_Mutator();
 }
 
-void reverseBuffer(unsigned char *buffer, int bufferSize) {
+void reverseBuffer(unsigned char* buffer, int bufferSize) {
   int elementCount = bufferSize / 4;
 
-  for (int loop_index = 0; loop_index < elementCount; loop_index++) {
+  for(int loop_index = 0; loop_index < elementCount; loop_index++) {
     std::swap(buffer[0], buffer[3]);
     std::swap(buffer[1], buffer[2]);
     buffer += 4;
   }
 }
 
-test_results_t aarch64_simd_Mutator::executeTest()
-{
+test_results_t aarch64_simd_Mutator::executeTest() {
   constexpr auto num_tests = 131;
 
-  std::array<unsigned char, 4*num_tests> buffer = {
-    0x4E, 0x30, 0x38, 0x20,     //SADDLV  H0, Q1.8B
-    0x0E, 0x30, 0xA9, 0x0F,     //SMAXV   B15, D8
-    0x6E, 0x70, 0x38, 0x42,     //UADDLV  S2, Q2
-    0x2E, 0x31, 0xA8, 0x05,     //UMINV   B5, D0
-    0x6E, 0x30, 0xC8, 0x25,     //FMAXNMV S5, Q1
-    0x0E, 0x11, 0x04, 0x41,     //DUP     D1, Q2
-    0x4E, 0x02, 0x0C, 0xD8,     //DUP     Q20, W5
-    0x0E, 0x18, 0x0C, 0x40,     //DUP     D0, X2
-    0x4E, 0x08, 0x1C, 0x04,     //INS     Q4, X0
-    0x4E, 0x01, 0x1F, 0xFF,     //INS     Q31, WZR
-    0x0E, 0x05, 0x2C, 0xA1,     //SMOV    W1, D5
-    0x4E, 0x10, 0x3C, 0x42,     //UMOV    X2, Q2
-    0x6E, 0x01, 0x04, 0x00,     //INS     Q0, D0
-    0x2E, 0x02, 0x28, 0x20,     //EXT     D0, D1, D2, #5
-    0x6E, 0x02, 0x7A, 0x08,     //EXT     Q8, Q16, Q2, #15
-    0x0F, 0x00, 0xE5, 0x00,     //MOVI    D0, #8
-    0x4F, 0x07, 0xA7, 0xE1,     //MOVI    Q1, FF LSL #8
-    0x0F, 0x00, 0x74, 0x05,     //ORR     D5, #0 LSL #24         ****
-    0x0F, 0x00, 0xB4, 0x05,     //ORR     D5, #0 LSL #8          ****
-    0x4F, 0x07, 0xF7, 0xE8,     //FMOV    Q8, FF                 ****
-    0x6F, 0x00, 0xC5, 0x80,     //MVNI    Q0, #12 LSL #8         ****
-    0x6F, 0x00, 0x97, 0x08,     //BIC     D8, #24 LSL #0         ****
-    0x2F, 0x07, 0xE7, 0xE2,     //MOVI    D2, (all ones)
-    0x0E, 0x00, 0x1A, 0x08,     //UZP1    D8, D16, D0
-    0x4E, 0x04, 0x28, 0x62,     //TRN1    Q2, Q3, Q4
-    0x0E, 0x08, 0x79, 0x08,     //ZIP2    D8, D8, D8
-    0x5E, 0x11, 0x04, 0x25,     //DUP     B5, Q1
-    0x5E, 0x08, 0x05, 0x08,     //DUP     D8, D8
-    0x5E, 0xF1, 0xB8, 0xA2,     //ADDP    D2, Q5
-    0x7E, 0x30, 0xC8, 0x81,     //FMAXNMP S1, D4
-    0x7E, 0xF0, 0xC9, 0xEF,     //FMINNMP D15, Q15
-    0x5F, 0x78, 0x04, 0x82,     //SSHR    D2, D4, #8
-    0x5F, 0x40, 0x14, 0x20,     //SSRA    D0, D1, #64
-    0x5F, 0x41, 0x57, 0xFF,     //SHL     D31, D31, #1
-    0x5F, 0x0E, 0x76, 0x08,     //SQSHL   B8, B16, 6
-    0x5F, 0x10, 0x9D, 0x02,     //SQRSHRN H2, H8, #16
-    0x5F, 0x20, 0xFC, 0x00,     //FCVTZS  S0, S0, #32
-    0x7F, 0x48, 0x55, 0x04,     //SLI     D4, D8, #8
-    0x7F, 0x09, 0x94, 0x42,     //UQSHRN  B2, H2, #7
-    0x5E, 0x60, 0x91, 0x08,     //SQDMLAL S8, H8, H0
-    0x5E, 0xA1, 0xB0, 0x82,     //SQDMLSL D2, S4, S1
-    0x5E, 0x7F, 0xD0, 0x00,     //SQDMULL S0, H0, H31
-    0x5E, 0xE0, 0x34, 0x22,     //CMGT    D2, D1, D0
-    0x5E, 0x64, 0x4C, 0x40,     //SQSHL   H0, H2, H4
-    0x5E, 0xA0, 0xB4, 0x3F,     //SQDMULH S31, S1, S0
-    0x5E, 0x68, 0xFD, 0x08,     //FRECPS  D8, D8, D8
-    0x7E, 0xE2, 0x57, 0xE4,     //URSHL   D4, D31, D2
-    0x7E, 0xB0, 0xE5, 0x02,     //FCMGT   S2, S8, S16
-    0x5E, 0x20, 0x39, 0x02,     //SUQADD  B2, B8
-    0x5E, 0x61, 0x48, 0x04,     //SQXTN   H4, S0
-    0x5E, 0x61, 0xB8, 0x3F,     //FCVTMS  D31, D1
-    0x5E, 0xA1, 0xD8, 0xA9,     //FRECPE  S9, S5
-    0x7E, 0x21, 0x28, 0x48,     //SQXTUN  B8, H2
-    0x7E, 0x61, 0x68, 0x4F,     //FCVTXN  S15, D2
-    0x7E, 0xA1, 0xDB, 0xFF,     //FRSQRTE S31, S31
-    0x5F, 0x49, 0x38, 0xA2,     //SQDMLAL S2, H5, Q9
-    0x5F, 0x9f, 0x73, 0xE0,     //SQDMLSL D0, S31, D31
-    0x5F, 0x4F, 0xD0, 0x88,     //SQRDMULH H8, H4, D15
-    0x5F, 0x94, 0x18, 0x49,     //FMLA    S9, S2, Q20
-    0x5F, 0xD1, 0x50, 0xA8,     //FMLS    D8, D5, D17
-    0x4E, 0x09, 0x01, 0x04,     //TBL     Q4, Q8, Q9
-    0x0E, 0x03, 0x30, 0x20,     //TBX     D0, D1, D2, D3
-    0x4E, 0x1F, 0x43, 0x00,     //TBL     Q0, Q24, Q25, Q26, Q31
-    0x0E, 0x15, 0x70, 0x14,     //TBX     D20, D0, D1, D2, D3, D21
-    0x4E, 0x23, 0x00, 0x41,     //SADDL   Q1, HQ2, HQ3
-    0x0E, 0x25, 0x20, 0x9F,     //SSUBL   Q31, D4, D5
-    0x4E, 0x30, 0x41, 0x02,     //ADDHN   HQ2, Q8, Q16
-    0x0E, 0x68, 0x70, 0x45,     //SABDL   Q5, D2, D8
-    0x4E, 0xA2, 0xB0, 0x20,     //SQDMLSL Q0, HQ1, HQ2
-    0x2E, 0x3F, 0x61, 0xE2,     //RSUBHN  D2, Q15, Q31
-    0x4E, 0x63, 0x60, 0x48,     //SUBHN   HQ8, Q2,Q3
-    0x0E, 0x25, 0x0C, 0x62,     //SQADD   D2, D3, D5
-    0x4E, 0x3F, 0x34, 0x20,     //CMGT    Q0, Q1, Q31
-    0x0E, 0x2A, 0x7D, 0x28,     //SABA    D8, D9, D10
-    0x6E, 0x66, 0x1C, 0xA4,     //BSL     Q4, Q5, Q6
-    0x0E, 0x20, 0x59, 0x28,     //CNT     D8, D9
-    0x4E, 0x21, 0x2B, 0xE0,     //XTN     Q0, Q31
-    0x4E, 0x61, 0xC8, 0x62,     //FCVTAS  Q2, Q3
-    0x2E, 0xA1, 0xF9, 0xFF,     //FSQRT   D31, D15
-    0x0F, 0x40, 0x20, 0xA2,     //SMLAL   Q2, D5, D0
-    0x4F, 0x85, 0x6B, 0xE1,     //SMLSL   Q1, HQ31, Q5
-    0x4F, 0x9F, 0x80, 0x49,     //MUL     Q9, Q2, D31
-    0x0F, 0x45, 0xB8, 0x88,     //SQDMULL Q8, D4, Q5
-    0x0F, 0x83, 0xD0, 0x41,     //SQRDMULH D1. D2, D3
-    0x4F, 0x8B, 0x59, 0x45,     //FMLS    Q5, Q10, Q11
-    0x6F, 0x9F, 0x21, 0x04,     //UMLAL   Q4, HQ8, D31
-    0x0F, 0x88, 0x19, 0x84,     //FMLA    D4, D12, Q8
-    0x4C, 0x00, 0x71, 0x04,     //ST1     Q4, [X8]
-    0x0C, 0x00, 0x83, 0xE9,     //ST2     D9, D10, [SP]
-    0x4C, 0x00, 0xA3, 0xC2,     //ST1     Q2, Q3, [X30]
-    0x4C, 0x40, 0x63, 0xFE,     //LD1     Q30, Q31, Q0, [SP]
-    0x0C, 0x40, 0x20, 0x01,     //LD1     D1, D2, D3, D4, [X0]
-    0x4C, 0x40, 0x40, 0x25,     //LD3     Q5, Q6, Q7, [X1]
-    0x0C, 0x94, 0x00, 0x40,     //ST4     D0, D1, D2, D3, [X2], X20
-    0x4C, 0x85, 0x23, 0xFE,     //ST1     Q30, Q31, Q0, Q1, [SP], X5
-    0x4C, 0x87, 0x61, 0x04,     //ST1     Q4, Q5, Q6, [X8], X7
-    0x0C, 0xDE, 0xA3, 0xFF,     //LD1     D31, D0, [SP], X30
-    0x4C, 0xC0, 0x71, 0x45,     //LD1     Q5, [X10], X0
-    0x0C, 0x9F, 0x43, 0xE5,     //ST3     D5, D6, D7, [SP], #24
-    0x4C, 0x9F, 0x20, 0x5F,     //ST1     Q31, Q0, Q1, Q2, [X2], #48
-    0x4C, 0xDF, 0x63, 0xE1,     //LD1     Q1, Q2, Q3, [SP], #48
-    0x0C, 0xDF, 0xA3, 0xDF,     //LD1     D31, D0, [X30], #16
-    0x4C, 0x9F, 0x70, 0x04,     //ST1     Q4, [X0], #16
-    0x4D, 0x00, 0x00, 0x45,     //ST1     Q5, [X2]
-    0x0D, 0x20, 0x43, 0xE4,     //ST2     D4, D5, [SP]
-    0x4D, 0x00, 0xA1, 0x1F,     //ST3     Q31, Q0, Q1, [X8]
-    0x0D, 0x20, 0xA7, 0xE0,     //ST4     D0, D1, D2, D3, [SP]
-    0x4D, 0x20, 0x43, 0xD5,     //ST2     Q21, Q22, [X30]
-    0x0D, 0x20, 0xA4, 0x1E,     //ST4     D30, D31, D0, D1, [X0]
-    0x4D, 0x40, 0x00, 0x45,     //LD1     Q5, [X2]
-    0x0D, 0x60, 0x43, 0xE4,     //LD2     D4, D5, [SP]
-    0x4D, 0x40, 0xA1, 0x1F,     //LD3     Q31, Q0, Q1, [X8]
-    0x0D, 0x60, 0xA7, 0xE0,     //LD4     D0, D1, D2, D3, [SP]
-    0x0D, 0x40, 0x80, 0x09,     //LD1     D9, [X0]
-    0x4D, 0x40, 0xA4, 0x21,     //LD3     Q1, Q2, Q3, [X1]
-    0x4D, 0x88, 0x00, 0x45,     //ST1     Q5, [X2], X8
-    0x0D, 0xBF, 0x43, 0xE4,     //ST2     D4, D5, [SP], #4
-    0x4D, 0x9E, 0xA1, 0x1F,     //ST3     Q31, Q0, Q1, [X8], X30
-    0x0D, 0xBF, 0xA7, 0xE0,     //ST4     D0, D1, D2, D3, [SP], #32
-    0x4D, 0xDF, 0x00, 0x45,     //LD1     Q5,[X2], #1
-    0x0D, 0xE0, 0x43, 0xE4,     //LD2     D4, D5, [SP], X0
-    0x4D, 0xDF, 0xA1, 0x1F,     //LD3     Q31, Q0, Q1, [X8], #12
-    0x0D, 0xE9, 0xA7, 0xE0,     //LD4     D0, D1, D2, D3, [SP], X9
-    0x0F, 0x08, 0x04, 0x82,     //SSHR    D2, D4, #8
-    0x4F, 0x40, 0x14, 0x20,     //SSRA    Q0, Q1, #64
-    0x0F, 0x09, 0x57, 0xFF,     //SHL     D31, D31, #1
-    0x4F, 0x30, 0x76, 0x08,     //SQSHL   Q8, Q16, #16
-    0x0F, 0x10, 0x9D, 0x02,     //SQRSHRN D2, D8, #16
-    0x4F, 0x20, 0xFC, 0x00,     //FCVTZS  Q0, Q0, #32
-    0x2F, 0x28, 0x55, 0x04,     //SLI     D4, D8, #8
-    0x6F, 0x09, 0x94, 0xA2      //UQSHRN  Q2, Q6, #7
+  // clang-format off
+  std::array<uint8_t, 4*num_tests> buffer = {
+    0x4e, 0x30, 0x38, 0x20,     // saddlv  h0, q1.8b
+    0x0e, 0x30, 0xa9, 0x0f,     // smaxv   b15, d8
+    0x6e, 0x70, 0x38, 0x42,     // uaddlv  s2, q2
+    0x2e, 0x31, 0xa8, 0x05,     // uminv   b5, d0
+    0x6e, 0x30, 0xc8, 0x25,     // fmaxnmv s5, q1
+    0x0e, 0x11, 0x04, 0x41,     // dup     d1, q2
+    0x4e, 0x02, 0x0c, 0xd8,     // dup     q20, w5
+    0x0e, 0x18, 0x0c, 0x40,     // dup     d0, x2
+    0x4e, 0x08, 0x1c, 0x04,     // ins     q4, x0
+    0x4e, 0x01, 0x1f, 0xff,     // ins     q31, wzr
+    0x0e, 0x05, 0x2c, 0xa1,     // smov    w1, d5
+    0x4e, 0x10, 0x3c, 0x42,     // umov    x2, q2
+    0x6e, 0x01, 0x04, 0x00,     // ins     q0, d0
+    0x2e, 0x02, 0x28, 0x20,     // ext     d0, d1, d2, #5
+    0x6e, 0x02, 0x7a, 0x08,     // ext     q8, q16, q2, #15
+    0x0f, 0x00, 0xe5, 0x00,     // movi    d0, #8
+    0x4f, 0x07, 0xa7, 0xe1,     // movi    q1, ff lsl #8
+    0x0f, 0x00, 0x74, 0x05,     // orr     d5, #0 lsl #24
+    0x0f, 0x00, 0xb4, 0x05,     // orr     d5, #0 lsl #8
+    0x4f, 0x07, 0xf7, 0xe8,     // fmov    q8, ff
+    0x6f, 0x00, 0xc5, 0x80,     // mvni    q0, #12 lsl #8
+    0x6f, 0x00, 0x97, 0x08,     // bic     d8, #24 lsl #0
+    0x2f, 0x07, 0xe7, 0xe2,     // movi    d2, (all ones)
+    0x0e, 0x00, 0x1a, 0x08,     // uzp1    d8, d16, d0
+    0x4e, 0x04, 0x28, 0x62,     // trn1    q2, q3, q4
+    0x0e, 0x08, 0x79, 0x08,     // zip2    d8, d8, d8
+    0x5e, 0x11, 0x04, 0x25,     // dup     b5, q1
+    0x5e, 0x08, 0x05, 0x08,     // dup     d8, d8
+    0x5e, 0xf1, 0xb8, 0xa2,     // addp    d2, q5
+    0x7e, 0x30, 0xc8, 0x81,     // fmaxnmp s1, d4
+    0x7e, 0xf0, 0xc9, 0xef,     // fminnmp d15, q15
+    0x5f, 0x78, 0x04, 0x82,     // sshr    d2, d4, #8
+    0x5f, 0x40, 0x14, 0x20,     // ssra    d0, d1, #64
+    0x5f, 0x41, 0x57, 0xff,     // shl     d31, d31, #1
+    0x5f, 0x0e, 0x76, 0x08,     // sqshl   b8, b16, 6
+    0x5f, 0x10, 0x9d, 0x02,     // sqrshrn h2, h8, #16
+    0x5f, 0x20, 0xfc, 0x00,     // fcvtzs  s0, s0, #32
+    0x7f, 0x48, 0x55, 0x04,     // sli     d4, d8, #8
+    0x7f, 0x09, 0x94, 0x42,     // uqshrn  b2, h2, #7
+    0x5e, 0x60, 0x91, 0x08,     // sqdmlal s8, h8, h0
+    0x5e, 0xa1, 0xb0, 0x82,     // sqdmlsl d2, s4, s1
+    0x5e, 0x7f, 0xd0, 0x00,     // sqdmull s0, h0, h31
+    0x5e, 0xe0, 0x34, 0x22,     // cmgt    d2, d1, d0
+    0x5e, 0x64, 0x4c, 0x40,     // sqshl   h0, h2, h4
+    0x5e, 0xa0, 0xb4, 0x3f,     // sqdmulh s31, s1, s0
+    0x5e, 0x68, 0xfd, 0x08,     // frecps  d8, d8, d8
+    0x7e, 0xe2, 0x57, 0xe4,     // urshl   d4, d31, d2
+    0x7e, 0xb0, 0xe5, 0x02,     // fcmgt   s2, s8, s16
+    0x5e, 0x20, 0x39, 0x02,     // suqadd  b2, b8
+    0x5e, 0x61, 0x48, 0x04,     // sqxtn   h4, s0
+    0x5e, 0x61, 0xb8, 0x3f,     // fcvtms  d31, d1
+    0x5e, 0xa1, 0xd8, 0xa9,     // frecpe  s9, s5
+    0x7e, 0x21, 0x28, 0x48,     // sqxtun  b8, h2
+    0x7e, 0x61, 0x68, 0x4f,     // fcvtxn  s15, d2
+    0x7e, 0xa1, 0xdb, 0xff,     // frsqrte s31, s31
+    0x5f, 0x49, 0x38, 0xa2,     // sqdmlal s2, h5, q9
+    0x5f, 0x9f, 0x73, 0xe0,     // sqdmlsl d0, s31, d31
+    0x5f, 0x4f, 0xd0, 0x88,     // sqrdmulh h8, h4, d15
+    0x5f, 0x94, 0x18, 0x49,     // fmla    s9, s2, q20
+    0x5f, 0xd1, 0x50, 0xa8,     // fmls    d8, d5, d17
+    0x4e, 0x09, 0x01, 0x04,     // tbl     q4, q8, q9
+    0x0e, 0x03, 0x30, 0x20,     // tbx     d0, d1, d2, d3
+    0x4e, 0x1f, 0x43, 0x00,     // tbl     q0, q24, q25, q26, q31
+    0x0e, 0x15, 0x70, 0x14,     // tbx     d20, d0, d1, d2, d3, d21
+    0x4e, 0x23, 0x00, 0x41,     // saddl   q1, hq2, hq3
+    0x0e, 0x25, 0x20, 0x9f,     // ssubl   q31, d4, d5
+    0x4e, 0x30, 0x41, 0x02,     // addhn   hq2, q8, q16
+    0x0e, 0x68, 0x70, 0x45,     // sabdl   q5, d2, d8
+    0x4e, 0xa2, 0xb0, 0x20,     // sqdmlsl q0, hq1, hq2
+    0x2e, 0x3f, 0x61, 0xe2,     // rsubhn  d2, q15, q31
+    0x4e, 0x63, 0x60, 0x48,     // subhn   hq8, q2,q3
+    0x0e, 0x25, 0x0c, 0x62,     // sqadd   d2, d3, d5
+    0x4e, 0x3f, 0x34, 0x20,     // cmgt    q0, q1, q31
+    0x0e, 0x2a, 0x7d, 0x28,     // saba    d8, d9, d10
+    0x6e, 0x66, 0x1c, 0xa4,     // bsl     q4, q5, q6
+    0x0e, 0x20, 0x59, 0x28,     // cnt     d8, d9
+    0x4e, 0x21, 0x2b, 0xe0,     // xtn     q0, q31
+    0x4e, 0x61, 0xc8, 0x62,     // fcvtas  q2, q3
+    0x2e, 0xa1, 0xf9, 0xff,     // fsqrt   d31, d15
+    0x0f, 0x40, 0x20, 0xa2,     // smlal   q2, d5, d0
+    0x4f, 0x85, 0x6b, 0xe1,     // smlsl   q1, hq31, q5
+    0x4f, 0x9f, 0x80, 0x49,     // mul     q9, q2, d31
+    0x0f, 0x45, 0xb8, 0x88,     // sqdmull q8, d4, q5
+    0x0f, 0x83, 0xd0, 0x41,     // sqrdmulh d1. d2, d3
+    0x4f, 0x8b, 0x59, 0x45,     // fmls    q5, q10, q11
+    0x6f, 0x9f, 0x21, 0x04,     // umlal   q4, hq8, d31
+    0x0f, 0x88, 0x19, 0x84,     // fmla    d4, d12, q8
+    0x4c, 0x00, 0x71, 0x04,     // st1     q4, [x8]
+    0x0c, 0x00, 0x83, 0xe9,     // st2     d9, d10, [sp]
+    0x4c, 0x00, 0xa3, 0xc2,     // st1     q2, q3, [x30]
+    0x4c, 0x40, 0x63, 0xfe,     // ld1     q30, q31, q0, [sp]
+    0x0c, 0x40, 0x20, 0x01,     // ld1     d1, d2, d3, d4, [x0]
+    0x4c, 0x40, 0x40, 0x25,     // ld3     q5, q6, q7, [x1]
+    0x0c, 0x94, 0x00, 0x40,     // st4     d0, d1, d2, d3, [x2], x20
+    0x4c, 0x85, 0x23, 0xfe,     // st1     q30, q31, q0, q1, [sp], x5
+    0x4c, 0x87, 0x61, 0x04,     // st1     q4, q5, q6, [x8], x7
+    0x0c, 0xde, 0xa3, 0xff,     // ld1     d31, d0, [sp], x30
+    0x4c, 0xc0, 0x71, 0x45,     // ld1     q5, [x10], x0
+    0x0c, 0x9f, 0x43, 0xe5,     // st3     d5, d6, d7, [sp], #24
+    0x4c, 0x9f, 0x20, 0x5f,     // st1     q31, q0, q1, q2, [x2], #48
+    0x4c, 0xdf, 0x63, 0xe1,     // ld1     q1, q2, q3, [sp], #48
+    0x0c, 0xdf, 0xa3, 0xdf,     // ld1     d31, d0, [x30], #16
+    0x4c, 0x9f, 0x70, 0x04,     // st1     q4, [x0], #16
+    0x4d, 0x00, 0x00, 0x45,     // st1     q5, [x2]
+    0x0d, 0x20, 0x43, 0xe4,     // st2     d4, d5, [sp]
+    0x4d, 0x00, 0xa1, 0x1f,     // st3     q31, q0, q1, [x8]
+    0x0d, 0x20, 0xa7, 0xe0,     // st4     d0, d1, d2, d3, [sp]
+    0x4d, 0x20, 0x43, 0xd5,     // st2     q21, q22, [x30]
+    0x0d, 0x20, 0xa4, 0x1e,     // st4     d30, d31, d0, d1, [x0]
+    0x4d, 0x40, 0x00, 0x45,     // ld1     q5, [x2]
+    0x0d, 0x60, 0x43, 0xe4,     // ld2     d4, d5, [sp]
+    0x4d, 0x40, 0xa1, 0x1f,     // ld3     q31, q0, q1, [x8]
+    0x0d, 0x60, 0xa7, 0xe0,     // ld4     d0, d1, d2, d3, [sp]
+    0x0d, 0x40, 0x80, 0x09,     // ld1     d9, [x0]
+    0x4d, 0x40, 0xa4, 0x21,     // ld3     q1, q2, q3, [x1]
+    0x4d, 0x88, 0x00, 0x45,     // st1     q5, [x2], x8
+    0x0d, 0xbf, 0x43, 0xe4,     // st2     d4, d5, [sp], #4
+    0x4d, 0x9e, 0xa1, 0x1f,     // st3     q31, q0, q1, [x8], x30
+    0x0d, 0xbf, 0xa7, 0xe0,     // st4     d0, d1, d2, d3, [sp], #32
+    0x4d, 0xdf, 0x00, 0x45,     // ld1     q5,[x2], #1
+    0x0d, 0xe0, 0x43, 0xe4,     // ld2     d4, d5, [sp], x0
+    0x4d, 0xdf, 0xa1, 0x1f,     // ld3     q31, q0, q1, [x8], #12
+    0x0d, 0xe9, 0xa7, 0xe0,     // ld4     d0, d1, d2, d3, [sp], x9
+    0x0f, 0x08, 0x04, 0x82,     // sshr    d2, d4, #8
+    0x4f, 0x40, 0x14, 0x20,     // ssra    q0, q1, #64
+    0x0f, 0x09, 0x57, 0xff,     // shl     d31, d31, #1
+    0x4f, 0x30, 0x76, 0x08,     // sqshl   q8, q16, #16
+    0x0f, 0x10, 0x9d, 0x02,     // sqrshrn d2, d8, #16
+    0x4f, 0x20, 0xfc, 0x00,     // fcvtzs  q0, q0, #32
+    0x2f, 0x28, 0x55, 0x04,     // sli     d4, d8, #8
+    0x6f, 0x09, 0x94, 0xa2      // uqshrn  q2, q6, #7
   };
+  // clang-format on
 
   reverseBuffer(buffer.data(), buffer.size());
   InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_aarch64);
 
   std::vector<Instruction> decodedInsns;
   decodedInsns.reserve(num_tests);
-  for(int idx=0; idx<num_tests; idx++) {
+  for(int idx = 0; idx < num_tests; idx++) {
     Instruction insn = d.decode();
     if(!insn.isValid()) {
-      logerror("Failed to decode test %d\n", idx+1);
+      logerror("Failed to decode test %d\n", idx + 1);
       return FAILED;
     }
     decodedInsns.push_back(insn);
   }
 
-  RegisterAST::Ptr zr (new RegisterAST(aarch64::xzr));
-  RegisterAST::Ptr wzr (new RegisterAST(aarch64::wzr));
+  auto create = [](MachRegister reg) {
+    return boost::make_shared<RegisterAST>(reg);
+  };
 
-  RegisterAST::Ptr x0 (new RegisterAST(aarch64::x0));
-  RegisterAST::Ptr x1 (new RegisterAST(aarch64::x1));
-  RegisterAST::Ptr x2 (new RegisterAST(aarch64::x2));
-  RegisterAST::Ptr x3 (new RegisterAST(aarch64::x3));
-  RegisterAST::Ptr x4 (new RegisterAST(aarch64::x4));
-  RegisterAST::Ptr x5 (new RegisterAST(aarch64::x5));
-  RegisterAST::Ptr x6 (new RegisterAST(aarch64::x6));
-  RegisterAST::Ptr x7 (new RegisterAST(aarch64::x7));
-  RegisterAST::Ptr x8 (new RegisterAST(aarch64::x8));
-  RegisterAST::Ptr x9 (new RegisterAST(aarch64::x9));
-  RegisterAST::Ptr x10(new RegisterAST(aarch64::x10));
-  RegisterAST::Ptr x11(new RegisterAST(aarch64::x11));
-  RegisterAST::Ptr x12(new RegisterAST(aarch64::x12));
-  RegisterAST::Ptr x13(new RegisterAST(aarch64::x13));
-  RegisterAST::Ptr x14(new RegisterAST(aarch64::x14));
-  RegisterAST::Ptr x15(new RegisterAST(aarch64::x15));
-  RegisterAST::Ptr x16(new RegisterAST(aarch64::x16));
-  RegisterAST::Ptr x17(new RegisterAST(aarch64::x17));
-  RegisterAST::Ptr x18(new RegisterAST(aarch64::x18));
-  RegisterAST::Ptr x19(new RegisterAST(aarch64::x19));
-  RegisterAST::Ptr x20(new RegisterAST(aarch64::x20));
-  RegisterAST::Ptr x21(new RegisterAST(aarch64::x21));
-  RegisterAST::Ptr x22(new RegisterAST(aarch64::x22));
-  RegisterAST::Ptr x23(new RegisterAST(aarch64::x23));
-  RegisterAST::Ptr x24(new RegisterAST(aarch64::x24));
-  RegisterAST::Ptr x25(new RegisterAST(aarch64::x25));
-  RegisterAST::Ptr x26(new RegisterAST(aarch64::x26));
-  RegisterAST::Ptr x27(new RegisterAST(aarch64::x27));
-  RegisterAST::Ptr x28(new RegisterAST(aarch64::x28));
-  RegisterAST::Ptr x29(new RegisterAST(aarch64::x29));
-  RegisterAST::Ptr x30(new RegisterAST(aarch64::x30));
+  RegisterAST::Ptr xzr = create(aarch64::xzr);
+  RegisterAST::Ptr wzr = create(aarch64::wzr);
 
-  RegisterAST::Ptr w0 (new RegisterAST(aarch64::w0));
-  RegisterAST::Ptr w1 (new RegisterAST(aarch64::w1));
-  RegisterAST::Ptr w2 (new RegisterAST(aarch64::w2));
-  RegisterAST::Ptr w3 (new RegisterAST(aarch64::w3));
-  RegisterAST::Ptr w4 (new RegisterAST(aarch64::w4));
-  RegisterAST::Ptr w5 (new RegisterAST(aarch64::w5));
-  RegisterAST::Ptr w6 (new RegisterAST(aarch64::w6));
-  RegisterAST::Ptr w7 (new RegisterAST(aarch64::w7));
-  RegisterAST::Ptr w8 (new RegisterAST(aarch64::w8));
-  RegisterAST::Ptr w9 (new RegisterAST(aarch64::w9));
-  RegisterAST::Ptr w10(new RegisterAST(aarch64::w10));
-  RegisterAST::Ptr w11(new RegisterAST(aarch64::w11));
-  RegisterAST::Ptr w12(new RegisterAST(aarch64::w12));
-  RegisterAST::Ptr w13(new RegisterAST(aarch64::w13));
-  RegisterAST::Ptr w14(new RegisterAST(aarch64::w14));
-  RegisterAST::Ptr w15(new RegisterAST(aarch64::w15));
-  RegisterAST::Ptr w16(new RegisterAST(aarch64::w16));
-  RegisterAST::Ptr w17(new RegisterAST(aarch64::w17));
-  RegisterAST::Ptr w18(new RegisterAST(aarch64::w18));
-  RegisterAST::Ptr w19(new RegisterAST(aarch64::w19));
-  RegisterAST::Ptr w20(new RegisterAST(aarch64::w20));
-  RegisterAST::Ptr w21(new RegisterAST(aarch64::w21));
-  RegisterAST::Ptr w22(new RegisterAST(aarch64::w22));
-  RegisterAST::Ptr w23(new RegisterAST(aarch64::w23));
-  RegisterAST::Ptr w24(new RegisterAST(aarch64::w24));
-  RegisterAST::Ptr w25(new RegisterAST(aarch64::w25));
-  RegisterAST::Ptr w26(new RegisterAST(aarch64::w26));
-  RegisterAST::Ptr w27(new RegisterAST(aarch64::w27));
-  RegisterAST::Ptr w28(new RegisterAST(aarch64::w28));
-  RegisterAST::Ptr w29(new RegisterAST(aarch64::w29));
-  RegisterAST::Ptr w30(new RegisterAST(aarch64::w30));
+  RegisterAST::Ptr x0 = create(aarch64::x0);
+  RegisterAST::Ptr x1 = create(aarch64::x1);
+  RegisterAST::Ptr x2 = create(aarch64::x2);
+  RegisterAST::Ptr x3 = create(aarch64::x3);
+  RegisterAST::Ptr x4 = create(aarch64::x4);
+  RegisterAST::Ptr x5 = create(aarch64::x5);
+  RegisterAST::Ptr x6 = create(aarch64::x6);
+  RegisterAST::Ptr x7 = create(aarch64::x7);
+  RegisterAST::Ptr x8 = create(aarch64::x8);
+  RegisterAST::Ptr x9 = create(aarch64::x9);
+  RegisterAST::Ptr x10 = create(aarch64::x10);
+  RegisterAST::Ptr x11 = create(aarch64::x11);
+  RegisterAST::Ptr x12 = create(aarch64::x12);
+  RegisterAST::Ptr x13 = create(aarch64::x13);
+  RegisterAST::Ptr x14 = create(aarch64::x14);
+  RegisterAST::Ptr x15 = create(aarch64::x15);
+  RegisterAST::Ptr x16 = create(aarch64::x16);
+  RegisterAST::Ptr x17 = create(aarch64::x17);
+  RegisterAST::Ptr x18 = create(aarch64::x18);
+  RegisterAST::Ptr x19 = create(aarch64::x19);
+  RegisterAST::Ptr x20 = create(aarch64::x20);
+  RegisterAST::Ptr x21 = create(aarch64::x21);
+  RegisterAST::Ptr x22 = create(aarch64::x22);
+  RegisterAST::Ptr x23 = create(aarch64::x23);
+  RegisterAST::Ptr x24 = create(aarch64::x24);
+  RegisterAST::Ptr x25 = create(aarch64::x25);
+  RegisterAST::Ptr x26 = create(aarch64::x26);
+  RegisterAST::Ptr x27 = create(aarch64::x27);
+  RegisterAST::Ptr x28 = create(aarch64::x28);
+  RegisterAST::Ptr x29 = create(aarch64::x29);
+  RegisterAST::Ptr x30 = create(aarch64::x30);
 
-  RegisterAST::Ptr q0 (new RegisterAST(aarch64::q0));
-  RegisterAST::Ptr q1 (new RegisterAST(aarch64::q1));
-  RegisterAST::Ptr q2 (new RegisterAST(aarch64::q2));
-  RegisterAST::Ptr q3 (new RegisterAST(aarch64::q3));
-  RegisterAST::Ptr q4 (new RegisterAST(aarch64::q4));
-  RegisterAST::Ptr q5 (new RegisterAST(aarch64::q5));
-  RegisterAST::Ptr q6 (new RegisterAST(aarch64::q6));
-  RegisterAST::Ptr q7 (new RegisterAST(aarch64::q7));
-  RegisterAST::Ptr q8 (new RegisterAST(aarch64::q8));
-  RegisterAST::Ptr q9 (new RegisterAST(aarch64::q9));
-  RegisterAST::Ptr q10(new RegisterAST(aarch64::q10));
-  RegisterAST::Ptr q11(new RegisterAST(aarch64::q11));
-  RegisterAST::Ptr q12(new RegisterAST(aarch64::q12));
-  RegisterAST::Ptr q13(new RegisterAST(aarch64::q13));
-  RegisterAST::Ptr q14(new RegisterAST(aarch64::q14));
-  RegisterAST::Ptr q15(new RegisterAST(aarch64::q15));
-  RegisterAST::Ptr q16(new RegisterAST(aarch64::q16));
-  RegisterAST::Ptr q17(new RegisterAST(aarch64::q17));
-  RegisterAST::Ptr q18(new RegisterAST(aarch64::q18));
-  RegisterAST::Ptr q19(new RegisterAST(aarch64::q19));
-  RegisterAST::Ptr q20(new RegisterAST(aarch64::q20));
-  RegisterAST::Ptr q21(new RegisterAST(aarch64::q21));
-  RegisterAST::Ptr q22(new RegisterAST(aarch64::q22));
-  RegisterAST::Ptr q23(new RegisterAST(aarch64::q23));
-  RegisterAST::Ptr q24(new RegisterAST(aarch64::q24));
-  RegisterAST::Ptr q25(new RegisterAST(aarch64::q25));
-  RegisterAST::Ptr q26(new RegisterAST(aarch64::q26));
-  RegisterAST::Ptr q27(new RegisterAST(aarch64::q27));
-  RegisterAST::Ptr q28(new RegisterAST(aarch64::q28));
-  RegisterAST::Ptr q29(new RegisterAST(aarch64::q29));
-  RegisterAST::Ptr q30(new RegisterAST(aarch64::q30));
-  RegisterAST::Ptr q31(new RegisterAST(aarch64::q31));
+  RegisterAST::Ptr w0 = create(aarch64::w0);
+  RegisterAST::Ptr w1 = create(aarch64::w1);
+  RegisterAST::Ptr w2 = create(aarch64::w2);
+  RegisterAST::Ptr w3 = create(aarch64::w3);
+  RegisterAST::Ptr w4 = create(aarch64::w4);
+  RegisterAST::Ptr w5 = create(aarch64::w5);
+  RegisterAST::Ptr w6 = create(aarch64::w6);
+  RegisterAST::Ptr w7 = create(aarch64::w7);
+  RegisterAST::Ptr w8 = create(aarch64::w8);
+  RegisterAST::Ptr w9 = create(aarch64::w9);
+  RegisterAST::Ptr w10 = create(aarch64::w10);
+  RegisterAST::Ptr w11 = create(aarch64::w11);
+  RegisterAST::Ptr w12 = create(aarch64::w12);
+  RegisterAST::Ptr w13 = create(aarch64::w13);
+  RegisterAST::Ptr w14 = create(aarch64::w14);
+  RegisterAST::Ptr w15 = create(aarch64::w15);
+  RegisterAST::Ptr w16 = create(aarch64::w16);
+  RegisterAST::Ptr w17 = create(aarch64::w17);
+  RegisterAST::Ptr w18 = create(aarch64::w18);
+  RegisterAST::Ptr w19 = create(aarch64::w19);
+  RegisterAST::Ptr w20 = create(aarch64::w20);
+  RegisterAST::Ptr w21 = create(aarch64::w21);
+  RegisterAST::Ptr w22 = create(aarch64::w22);
+  RegisterAST::Ptr w23 = create(aarch64::w23);
+  RegisterAST::Ptr w24 = create(aarch64::w24);
+  RegisterAST::Ptr w25 = create(aarch64::w25);
+  RegisterAST::Ptr w26 = create(aarch64::w26);
+  RegisterAST::Ptr w27 = create(aarch64::w27);
+  RegisterAST::Ptr w28 = create(aarch64::w28);
+  RegisterAST::Ptr w29 = create(aarch64::w29);
+  RegisterAST::Ptr w30 = create(aarch64::w30);
 
-  RegisterAST::Ptr s0 (new RegisterAST(aarch64::s0));
-  RegisterAST::Ptr s1 (new RegisterAST(aarch64::s1));
-  RegisterAST::Ptr s2 (new RegisterAST(aarch64::s2));
-  RegisterAST::Ptr s3 (new RegisterAST(aarch64::s3));
-  RegisterAST::Ptr s4 (new RegisterAST(aarch64::s4));
-  RegisterAST::Ptr s5 (new RegisterAST(aarch64::s5));
-  RegisterAST::Ptr s6 (new RegisterAST(aarch64::s6));
-  RegisterAST::Ptr s7 (new RegisterAST(aarch64::s7));
-  RegisterAST::Ptr s8 (new RegisterAST(aarch64::s8));
-  RegisterAST::Ptr s9 (new RegisterAST(aarch64::s9));
-  RegisterAST::Ptr s10(new RegisterAST(aarch64::s10));
-  RegisterAST::Ptr s11(new RegisterAST(aarch64::s11));
-  RegisterAST::Ptr s12(new RegisterAST(aarch64::s12));
-  RegisterAST::Ptr s13(new RegisterAST(aarch64::s13));
-  RegisterAST::Ptr s14(new RegisterAST(aarch64::s14));
-  RegisterAST::Ptr s15(new RegisterAST(aarch64::s15));
-  RegisterAST::Ptr s16(new RegisterAST(aarch64::s16));
-  RegisterAST::Ptr s17(new RegisterAST(aarch64::s17));
-  RegisterAST::Ptr s18(new RegisterAST(aarch64::s18));
-  RegisterAST::Ptr s19(new RegisterAST(aarch64::s19));
-  RegisterAST::Ptr s20(new RegisterAST(aarch64::s20));
-  RegisterAST::Ptr s21(new RegisterAST(aarch64::s21));
-  RegisterAST::Ptr s22(new RegisterAST(aarch64::s22));
-  RegisterAST::Ptr s23(new RegisterAST(aarch64::s23));
-  RegisterAST::Ptr s24(new RegisterAST(aarch64::s24));
-  RegisterAST::Ptr s25(new RegisterAST(aarch64::s25));
-  RegisterAST::Ptr s26(new RegisterAST(aarch64::s26));
-  RegisterAST::Ptr s27(new RegisterAST(aarch64::s27));
-  RegisterAST::Ptr s28(new RegisterAST(aarch64::s28));
-  RegisterAST::Ptr s29(new RegisterAST(aarch64::s29));
-  RegisterAST::Ptr s30(new RegisterAST(aarch64::s30));
-  RegisterAST::Ptr s31(new RegisterAST(aarch64::s31));
+  RegisterAST::Ptr q0 = create(aarch64::q0);
+  RegisterAST::Ptr q1 = create(aarch64::q1);
+  RegisterAST::Ptr q2 = create(aarch64::q2);
+  RegisterAST::Ptr q3 = create(aarch64::q3);
+  RegisterAST::Ptr q4 = create(aarch64::q4);
+  RegisterAST::Ptr q5 = create(aarch64::q5);
+  RegisterAST::Ptr q6 = create(aarch64::q6);
+  RegisterAST::Ptr q7 = create(aarch64::q7);
+  RegisterAST::Ptr q8 = create(aarch64::q8);
+  RegisterAST::Ptr q9 = create(aarch64::q9);
+  RegisterAST::Ptr q10 = create(aarch64::q10);
+  RegisterAST::Ptr q11 = create(aarch64::q11);
+  RegisterAST::Ptr q12 = create(aarch64::q12);
+  RegisterAST::Ptr q13 = create(aarch64::q13);
+  RegisterAST::Ptr q14 = create(aarch64::q14);
+  RegisterAST::Ptr q15 = create(aarch64::q15);
+  RegisterAST::Ptr q16 = create(aarch64::q16);
+  RegisterAST::Ptr q17 = create(aarch64::q17);
+  RegisterAST::Ptr q18 = create(aarch64::q18);
+  RegisterAST::Ptr q19 = create(aarch64::q19);
+  RegisterAST::Ptr q20 = create(aarch64::q20);
+  RegisterAST::Ptr q21 = create(aarch64::q21);
+  RegisterAST::Ptr q22 = create(aarch64::q22);
+  RegisterAST::Ptr q23 = create(aarch64::q23);
+  RegisterAST::Ptr q24 = create(aarch64::q24);
+  RegisterAST::Ptr q25 = create(aarch64::q25);
+  RegisterAST::Ptr q26 = create(aarch64::q26);
+  RegisterAST::Ptr q27 = create(aarch64::q27);
+  RegisterAST::Ptr q28 = create(aarch64::q28);
+  RegisterAST::Ptr q29 = create(aarch64::q29);
+  RegisterAST::Ptr q30 = create(aarch64::q30);
+  RegisterAST::Ptr q31 = create(aarch64::q31);
 
-  RegisterAST::Ptr h0 (new RegisterAST(aarch64::h0));
-  RegisterAST::Ptr h1 (new RegisterAST(aarch64::h1));
-  RegisterAST::Ptr h2 (new RegisterAST(aarch64::h2));
-  RegisterAST::Ptr h3 (new RegisterAST(aarch64::h3));
-  RegisterAST::Ptr h4 (new RegisterAST(aarch64::h4));
-  RegisterAST::Ptr h5 (new RegisterAST(aarch64::h5));
-  RegisterAST::Ptr h6 (new RegisterAST(aarch64::h6));
-  RegisterAST::Ptr h7 (new RegisterAST(aarch64::h7));
-  RegisterAST::Ptr h8 (new RegisterAST(aarch64::h8));
-  RegisterAST::Ptr h9 (new RegisterAST(aarch64::h9));
-  RegisterAST::Ptr h10(new RegisterAST(aarch64::h10));
-  RegisterAST::Ptr h11(new RegisterAST(aarch64::h11));
-  RegisterAST::Ptr h12(new RegisterAST(aarch64::h12));
-  RegisterAST::Ptr h13(new RegisterAST(aarch64::h13));
-  RegisterAST::Ptr h14(new RegisterAST(aarch64::h14));
-  RegisterAST::Ptr h15(new RegisterAST(aarch64::h15));
-  RegisterAST::Ptr h16(new RegisterAST(aarch64::h16));
-  RegisterAST::Ptr h17(new RegisterAST(aarch64::h17));
-  RegisterAST::Ptr h18(new RegisterAST(aarch64::h18));
-  RegisterAST::Ptr h19(new RegisterAST(aarch64::h19));
-  RegisterAST::Ptr h20(new RegisterAST(aarch64::h20));
-  RegisterAST::Ptr h21(new RegisterAST(aarch64::h21));
-  RegisterAST::Ptr h22(new RegisterAST(aarch64::h22));
-  RegisterAST::Ptr h23(new RegisterAST(aarch64::h23));
-  RegisterAST::Ptr h24(new RegisterAST(aarch64::h24));
-  RegisterAST::Ptr h25(new RegisterAST(aarch64::h25));
-  RegisterAST::Ptr h26(new RegisterAST(aarch64::h26));
-  RegisterAST::Ptr h27(new RegisterAST(aarch64::h27));
-  RegisterAST::Ptr h28(new RegisterAST(aarch64::h28));
-  RegisterAST::Ptr h29(new RegisterAST(aarch64::h29));
-  RegisterAST::Ptr h30(new RegisterAST(aarch64::h30));
-  RegisterAST::Ptr h31(new RegisterAST(aarch64::h31));
+  RegisterAST::Ptr s0 = create(aarch64::s0);
+  RegisterAST::Ptr s1 = create(aarch64::s1);
+  RegisterAST::Ptr s2 = create(aarch64::s2);
+  RegisterAST::Ptr s3 = create(aarch64::s3);
+  RegisterAST::Ptr s4 = create(aarch64::s4);
+  RegisterAST::Ptr s5 = create(aarch64::s5);
+  RegisterAST::Ptr s6 = create(aarch64::s6);
+  RegisterAST::Ptr s7 = create(aarch64::s7);
+  RegisterAST::Ptr s8 = create(aarch64::s8);
+  RegisterAST::Ptr s9 = create(aarch64::s9);
+  RegisterAST::Ptr s10 = create(aarch64::s10);
+  RegisterAST::Ptr s11 = create(aarch64::s11);
+  RegisterAST::Ptr s12 = create(aarch64::s12);
+  RegisterAST::Ptr s13 = create(aarch64::s13);
+  RegisterAST::Ptr s14 = create(aarch64::s14);
+  RegisterAST::Ptr s15 = create(aarch64::s15);
+  RegisterAST::Ptr s16 = create(aarch64::s16);
+  RegisterAST::Ptr s17 = create(aarch64::s17);
+  RegisterAST::Ptr s18 = create(aarch64::s18);
+  RegisterAST::Ptr s19 = create(aarch64::s19);
+  RegisterAST::Ptr s20 = create(aarch64::s20);
+  RegisterAST::Ptr s21 = create(aarch64::s21);
+  RegisterAST::Ptr s22 = create(aarch64::s22);
+  RegisterAST::Ptr s23 = create(aarch64::s23);
+  RegisterAST::Ptr s24 = create(aarch64::s24);
+  RegisterAST::Ptr s25 = create(aarch64::s25);
+  RegisterAST::Ptr s26 = create(aarch64::s26);
+  RegisterAST::Ptr s27 = create(aarch64::s27);
+  RegisterAST::Ptr s28 = create(aarch64::s28);
+  RegisterAST::Ptr s29 = create(aarch64::s29);
+  RegisterAST::Ptr s30 = create(aarch64::s30);
+  RegisterAST::Ptr s31 = create(aarch64::s31);
 
-  RegisterAST::Ptr d0 (new RegisterAST(aarch64::d0));
-  RegisterAST::Ptr d1 (new RegisterAST(aarch64::d1));
-  RegisterAST::Ptr d2 (new RegisterAST(aarch64::d2));
-  RegisterAST::Ptr d3 (new RegisterAST(aarch64::d3));
-  RegisterAST::Ptr d4 (new RegisterAST(aarch64::d4));
-  RegisterAST::Ptr d5 (new RegisterAST(aarch64::d5));
-  RegisterAST::Ptr d6 (new RegisterAST(aarch64::d6));
-  RegisterAST::Ptr d7 (new RegisterAST(aarch64::d7));
-  RegisterAST::Ptr d8 (new RegisterAST(aarch64::d8));
-  RegisterAST::Ptr d9 (new RegisterAST(aarch64::d9));
-  RegisterAST::Ptr d10(new RegisterAST(aarch64::d10));
-  RegisterAST::Ptr d11(new RegisterAST(aarch64::d11));
-  RegisterAST::Ptr d12(new RegisterAST(aarch64::d12));
-  RegisterAST::Ptr d13(new RegisterAST(aarch64::d13));
-  RegisterAST::Ptr d14(new RegisterAST(aarch64::d14));
-  RegisterAST::Ptr d15(new RegisterAST(aarch64::d15));
-  RegisterAST::Ptr d16(new RegisterAST(aarch64::d16));
-  RegisterAST::Ptr d17(new RegisterAST(aarch64::d17));
-  RegisterAST::Ptr d18(new RegisterAST(aarch64::d18));
-  RegisterAST::Ptr d19(new RegisterAST(aarch64::d19));
-  RegisterAST::Ptr d20(new RegisterAST(aarch64::d20));
-  RegisterAST::Ptr d21(new RegisterAST(aarch64::d21));
-  RegisterAST::Ptr d22(new RegisterAST(aarch64::d22));
-  RegisterAST::Ptr d23(new RegisterAST(aarch64::d23));
-  RegisterAST::Ptr d24(new RegisterAST(aarch64::d24));
-  RegisterAST::Ptr d25(new RegisterAST(aarch64::d25));
-  RegisterAST::Ptr d26(new RegisterAST(aarch64::d26));
-  RegisterAST::Ptr d27(new RegisterAST(aarch64::d27));
-  RegisterAST::Ptr d28(new RegisterAST(aarch64::d28));
-  RegisterAST::Ptr d29(new RegisterAST(aarch64::d29));
-  RegisterAST::Ptr d30(new RegisterAST(aarch64::d30));
-  RegisterAST::Ptr d31(new RegisterAST(aarch64::d31));
+  RegisterAST::Ptr h0 = create(aarch64::h0);
+  RegisterAST::Ptr h1 = create(aarch64::h1);
+  RegisterAST::Ptr h2 = create(aarch64::h2);
+  RegisterAST::Ptr h3 = create(aarch64::h3);
+  RegisterAST::Ptr h4 = create(aarch64::h4);
+  RegisterAST::Ptr h5 = create(aarch64::h5);
+  RegisterAST::Ptr h6 = create(aarch64::h6);
+  RegisterAST::Ptr h7 = create(aarch64::h7);
+  RegisterAST::Ptr h8 = create(aarch64::h8);
+  RegisterAST::Ptr h9 = create(aarch64::h9);
+  RegisterAST::Ptr h10 = create(aarch64::h10);
+  RegisterAST::Ptr h11 = create(aarch64::h11);
+  RegisterAST::Ptr h12 = create(aarch64::h12);
+  RegisterAST::Ptr h13 = create(aarch64::h13);
+  RegisterAST::Ptr h14 = create(aarch64::h14);
+  RegisterAST::Ptr h15 = create(aarch64::h15);
+  RegisterAST::Ptr h16 = create(aarch64::h16);
+  RegisterAST::Ptr h17 = create(aarch64::h17);
+  RegisterAST::Ptr h18 = create(aarch64::h18);
+  RegisterAST::Ptr h19 = create(aarch64::h19);
+  RegisterAST::Ptr h20 = create(aarch64::h20);
+  RegisterAST::Ptr h21 = create(aarch64::h21);
+  RegisterAST::Ptr h22 = create(aarch64::h22);
+  RegisterAST::Ptr h23 = create(aarch64::h23);
+  RegisterAST::Ptr h24 = create(aarch64::h24);
+  RegisterAST::Ptr h25 = create(aarch64::h25);
+  RegisterAST::Ptr h26 = create(aarch64::h26);
+  RegisterAST::Ptr h27 = create(aarch64::h27);
+  RegisterAST::Ptr h28 = create(aarch64::h28);
+  RegisterAST::Ptr h29 = create(aarch64::h29);
+  RegisterAST::Ptr h30 = create(aarch64::h30);
+  RegisterAST::Ptr h31 = create(aarch64::h31);
 
-  RegisterAST::Ptr b0 (new RegisterAST(aarch64::b0));
-  RegisterAST::Ptr b1 (new RegisterAST(aarch64::b1));
-  RegisterAST::Ptr b2 (new RegisterAST(aarch64::b2));
-  RegisterAST::Ptr b3 (new RegisterAST(aarch64::b3));
-  RegisterAST::Ptr b4 (new RegisterAST(aarch64::b4));
-  RegisterAST::Ptr b5 (new RegisterAST(aarch64::b5));
-  RegisterAST::Ptr b6 (new RegisterAST(aarch64::b6));
-  RegisterAST::Ptr b7 (new RegisterAST(aarch64::b7));
-  RegisterAST::Ptr b8 (new RegisterAST(aarch64::b8));
-  RegisterAST::Ptr b9 (new RegisterAST(aarch64::b9));
-  RegisterAST::Ptr b10(new RegisterAST(aarch64::b10));
-  RegisterAST::Ptr b11(new RegisterAST(aarch64::b11));
-  RegisterAST::Ptr b12(new RegisterAST(aarch64::b12));
-  RegisterAST::Ptr b13(new RegisterAST(aarch64::b13));
-  RegisterAST::Ptr b14(new RegisterAST(aarch64::b14));
-  RegisterAST::Ptr b15(new RegisterAST(aarch64::b15));
-  RegisterAST::Ptr b16(new RegisterAST(aarch64::b16));
-  RegisterAST::Ptr b17(new RegisterAST(aarch64::b17));
-  RegisterAST::Ptr b18(new RegisterAST(aarch64::b18));
-  RegisterAST::Ptr b19(new RegisterAST(aarch64::b19));
-  RegisterAST::Ptr b20(new RegisterAST(aarch64::b20));
-  RegisterAST::Ptr b21(new RegisterAST(aarch64::b21));
-  RegisterAST::Ptr b22(new RegisterAST(aarch64::b22));
-  RegisterAST::Ptr b23(new RegisterAST(aarch64::b23));
-  RegisterAST::Ptr b24(new RegisterAST(aarch64::b24));
-  RegisterAST::Ptr b25(new RegisterAST(aarch64::b25));
-  RegisterAST::Ptr b26(new RegisterAST(aarch64::b26));
-  RegisterAST::Ptr b27(new RegisterAST(aarch64::b27));
-  RegisterAST::Ptr b28(new RegisterAST(aarch64::b28));
-  RegisterAST::Ptr b29(new RegisterAST(aarch64::b29));
-  RegisterAST::Ptr b30(new RegisterAST(aarch64::b30));
-  RegisterAST::Ptr b31(new RegisterAST(aarch64::b31));
+  RegisterAST::Ptr d0 = create(aarch64::d0);
+  RegisterAST::Ptr d1 = create(aarch64::d1);
+  RegisterAST::Ptr d2 = create(aarch64::d2);
+  RegisterAST::Ptr d3 = create(aarch64::d3);
+  RegisterAST::Ptr d4 = create(aarch64::d4);
+  RegisterAST::Ptr d5 = create(aarch64::d5);
+  RegisterAST::Ptr d6 = create(aarch64::d6);
+  RegisterAST::Ptr d7 = create(aarch64::d7);
+  RegisterAST::Ptr d8 = create(aarch64::d8);
+  RegisterAST::Ptr d9 = create(aarch64::d9);
+  RegisterAST::Ptr d10 = create(aarch64::d10);
+  RegisterAST::Ptr d11 = create(aarch64::d11);
+  RegisterAST::Ptr d12 = create(aarch64::d12);
+  RegisterAST::Ptr d13 = create(aarch64::d13);
+  RegisterAST::Ptr d14 = create(aarch64::d14);
+  RegisterAST::Ptr d15 = create(aarch64::d15);
+  RegisterAST::Ptr d16 = create(aarch64::d16);
+  RegisterAST::Ptr d17 = create(aarch64::d17);
+  RegisterAST::Ptr d18 = create(aarch64::d18);
+  RegisterAST::Ptr d19 = create(aarch64::d19);
+  RegisterAST::Ptr d20 = create(aarch64::d20);
+  RegisterAST::Ptr d21 = create(aarch64::d21);
+  RegisterAST::Ptr d22 = create(aarch64::d22);
+  RegisterAST::Ptr d23 = create(aarch64::d23);
+  RegisterAST::Ptr d24 = create(aarch64::d24);
+  RegisterAST::Ptr d25 = create(aarch64::d25);
+  RegisterAST::Ptr d26 = create(aarch64::d26);
+  RegisterAST::Ptr d27 = create(aarch64::d27);
+  RegisterAST::Ptr d28 = create(aarch64::d28);
+  RegisterAST::Ptr d29 = create(aarch64::d29);
+  RegisterAST::Ptr d30 = create(aarch64::d30);
+  RegisterAST::Ptr d31 = create(aarch64::d31);
 
-  RegisterAST::Ptr hq0 (new RegisterAST(aarch64::hq0));
-  RegisterAST::Ptr hq1 (new RegisterAST(aarch64::hq1));
-  RegisterAST::Ptr hq2 (new RegisterAST(aarch64::hq2));
-  RegisterAST::Ptr hq3 (new RegisterAST(aarch64::hq3));
-  RegisterAST::Ptr hq4 (new RegisterAST(aarch64::hq4));
-  RegisterAST::Ptr hq5 (new RegisterAST(aarch64::hq5));
-  RegisterAST::Ptr hq6 (new RegisterAST(aarch64::hq6));
-  RegisterAST::Ptr hq7 (new RegisterAST(aarch64::hq7));
-  RegisterAST::Ptr hq8 (new RegisterAST(aarch64::hq8));
-  RegisterAST::Ptr hq9 (new RegisterAST(aarch64::hq9));
-  RegisterAST::Ptr hq10(new RegisterAST(aarch64::hq10));
-  RegisterAST::Ptr hq11(new RegisterAST(aarch64::hq11));
-  RegisterAST::Ptr hq12(new RegisterAST(aarch64::hq12));
-  RegisterAST::Ptr hq13(new RegisterAST(aarch64::hq13));
-  RegisterAST::Ptr hq14(new RegisterAST(aarch64::hq14));
-  RegisterAST::Ptr hq15(new RegisterAST(aarch64::hq15));
-  RegisterAST::Ptr hq16(new RegisterAST(aarch64::hq16));
-  RegisterAST::Ptr hq17(new RegisterAST(aarch64::hq17));
-  RegisterAST::Ptr hq18(new RegisterAST(aarch64::hq18));
-  RegisterAST::Ptr hq19(new RegisterAST(aarch64::hq19));
-  RegisterAST::Ptr hq20(new RegisterAST(aarch64::hq20));
-  RegisterAST::Ptr hq21(new RegisterAST(aarch64::hq21));
-  RegisterAST::Ptr hq22(new RegisterAST(aarch64::hq22));
-  RegisterAST::Ptr hq23(new RegisterAST(aarch64::hq23));
-  RegisterAST::Ptr hq24(new RegisterAST(aarch64::hq24));
-  RegisterAST::Ptr hq25(new RegisterAST(aarch64::hq25));
-  RegisterAST::Ptr hq26(new RegisterAST(aarch64::hq26));
-  RegisterAST::Ptr hq27(new RegisterAST(aarch64::hq27));
-  RegisterAST::Ptr hq28(new RegisterAST(aarch64::hq28));
-  RegisterAST::Ptr hq29(new RegisterAST(aarch64::hq29));
-  RegisterAST::Ptr hq30(new RegisterAST(aarch64::hq30));
-  RegisterAST::Ptr hq31(new RegisterAST(aarch64::hq31));
+  RegisterAST::Ptr b0 = create(aarch64::b0);
+  RegisterAST::Ptr b1 = create(aarch64::b1);
+  RegisterAST::Ptr b2 = create(aarch64::b2);
+  RegisterAST::Ptr b3 = create(aarch64::b3);
+  RegisterAST::Ptr b4 = create(aarch64::b4);
+  RegisterAST::Ptr b5 = create(aarch64::b5);
+  RegisterAST::Ptr b6 = create(aarch64::b6);
+  RegisterAST::Ptr b7 = create(aarch64::b7);
+  RegisterAST::Ptr b8 = create(aarch64::b8);
+  RegisterAST::Ptr b9 = create(aarch64::b9);
+  RegisterAST::Ptr b10 = create(aarch64::b10);
+  RegisterAST::Ptr b11 = create(aarch64::b11);
+  RegisterAST::Ptr b12 = create(aarch64::b12);
+  RegisterAST::Ptr b13 = create(aarch64::b13);
+  RegisterAST::Ptr b14 = create(aarch64::b14);
+  RegisterAST::Ptr b15 = create(aarch64::b15);
+  RegisterAST::Ptr b16 = create(aarch64::b16);
+  RegisterAST::Ptr b17 = create(aarch64::b17);
+  RegisterAST::Ptr b18 = create(aarch64::b18);
+  RegisterAST::Ptr b19 = create(aarch64::b19);
+  RegisterAST::Ptr b20 = create(aarch64::b20);
+  RegisterAST::Ptr b21 = create(aarch64::b21);
+  RegisterAST::Ptr b22 = create(aarch64::b22);
+  RegisterAST::Ptr b23 = create(aarch64::b23);
+  RegisterAST::Ptr b24 = create(aarch64::b24);
+  RegisterAST::Ptr b25 = create(aarch64::b25);
+  RegisterAST::Ptr b26 = create(aarch64::b26);
+  RegisterAST::Ptr b27 = create(aarch64::b27);
+  RegisterAST::Ptr b28 = create(aarch64::b28);
+  RegisterAST::Ptr b29 = create(aarch64::b29);
+  RegisterAST::Ptr b30 = create(aarch64::b30);
+  RegisterAST::Ptr b31 = create(aarch64::b31);
+
+  RegisterAST::Ptr hq0 = create(aarch64::hq0);
+  RegisterAST::Ptr hq1 = create(aarch64::hq1);
+  RegisterAST::Ptr hq2 = create(aarch64::hq2);
+  RegisterAST::Ptr hq3 = create(aarch64::hq3);
+  RegisterAST::Ptr hq4 = create(aarch64::hq4);
+  RegisterAST::Ptr hq5 = create(aarch64::hq5);
+  RegisterAST::Ptr hq6 = create(aarch64::hq6);
+  RegisterAST::Ptr hq7 = create(aarch64::hq7);
+  RegisterAST::Ptr hq8 = create(aarch64::hq8);
+  RegisterAST::Ptr hq9 = create(aarch64::hq9);
+  RegisterAST::Ptr hq10 = create(aarch64::hq10);
+  RegisterAST::Ptr hq11 = create(aarch64::hq11);
+  RegisterAST::Ptr hq12 = create(aarch64::hq12);
+  RegisterAST::Ptr hq13 = create(aarch64::hq13);
+  RegisterAST::Ptr hq14 = create(aarch64::hq14);
+  RegisterAST::Ptr hq15 = create(aarch64::hq15);
+  RegisterAST::Ptr hq16 = create(aarch64::hq16);
+  RegisterAST::Ptr hq17 = create(aarch64::hq17);
+  RegisterAST::Ptr hq18 = create(aarch64::hq18);
+  RegisterAST::Ptr hq19 = create(aarch64::hq19);
+  RegisterAST::Ptr hq20 = create(aarch64::hq20);
+  RegisterAST::Ptr hq21 = create(aarch64::hq21);
+  RegisterAST::Ptr hq22 = create(aarch64::hq22);
+  RegisterAST::Ptr hq23 = create(aarch64::hq23);
+  RegisterAST::Ptr hq24 = create(aarch64::hq24);
+  RegisterAST::Ptr hq25 = create(aarch64::hq25);
+  RegisterAST::Ptr hq26 = create(aarch64::hq26);
+  RegisterAST::Ptr hq27 = create(aarch64::hq27);
+  RegisterAST::Ptr hq28 = create(aarch64::hq28);
+  RegisterAST::Ptr hq29 = create(aarch64::hq29);
+  RegisterAST::Ptr hq30 = create(aarch64::hq30);
+  RegisterAST::Ptr hq31 = create(aarch64::hq31);
 
   RegisterAST::Ptr sp(new RegisterAST(aarch64::sp));
 
@@ -540,11 +543,11 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedWritten.push_back({q0});
 
   // EXT D0, D1, D2, #5
-  expectedRead.push_back({d1,d2});
+  expectedRead.push_back({d1, d2});
   expectedWritten.push_back({d0});
 
   // EXT Q8, Q16, Q2, #15
-  expectedRead.push_back({q16,q2});
+  expectedRead.push_back({q16, q2});
   expectedWritten.push_back({q8});
 
   // MOVI D0, #8
@@ -580,11 +583,11 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedWritten.push_back({d2});
 
   // UZP1 D8, D16, D0
-  expectedRead.push_back({d16,d0});
+  expectedRead.push_back({d16, d0});
   expectedWritten.push_back({d8});
 
   // TRN1 Q2, Q3, Q4
-  expectedRead.push_back({q3,q4});
+  expectedRead.push_back({q3, q4});
   expectedWritten.push_back({q2});
 
   // ZIP2 D8, D8, D8
@@ -644,27 +647,27 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedWritten.push_back({b2});
 
   // SQDMLAL S8, H8, H0
-  expectedRead.push_back({h8,h0});
+  expectedRead.push_back({h8, h0});
   expectedWritten.push_back({s8});
 
   // SQDMLSL D2, S4, S1
-  expectedRead.push_back({s4,s1});
+  expectedRead.push_back({s4, s1});
   expectedWritten.push_back({d2});
 
   // SQDMULL S0, H0, H31
-  expectedRead.push_back({h0,h31});
+  expectedRead.push_back({h0, h31});
   expectedWritten.push_back({s0});
 
   // CMGT D2, D1, D0
-  expectedRead.push_back({d1,d0});
+  expectedRead.push_back({d1, d0});
   expectedWritten.push_back({d2});
 
   // SQSHL H0, H2, H4
-  expectedRead.push_back({h2,h4});
+  expectedRead.push_back({h2, h4});
   expectedWritten.push_back({h0});
 
   // SQDMULH S31, S1, S0
-  expectedRead.push_back({s1,s0});
+  expectedRead.push_back({s1, s0});
   expectedWritten.push_back({s31});
 
   // FRECPS D8, D8, D8
@@ -672,11 +675,11 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedWritten.push_back({d8});
 
   // URSHL D4, D31, D2
-  expectedRead.push_back({d31,d2});
+  expectedRead.push_back({d31, d2});
   expectedWritten.push_back({d4});
 
   // FCMGT S2, S8, S16
-  expectedRead.push_back({s8,s16});
+  expectedRead.push_back({s8, s16});
   expectedWritten.push_back({s2});
 
   // SUQADD B2, B8
@@ -708,83 +711,83 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedWritten.push_back({s31});
 
   // SQDMLAL S2, H5, Q9
-  expectedRead.push_back({s2,h5,q9});
+  expectedRead.push_back({s2, h5, q9});
   expectedWritten.push_back({s2});
 
   // SQDMLSL D0, S31, D31
-  expectedRead.push_back({d0,d31,s31});
+  expectedRead.push_back({d0, d31, s31});
   expectedWritten.push_back({d0});
 
   // SQRDMULH H8, H4, D15
-  expectedRead.push_back({h4,d15});
+  expectedRead.push_back({h4, d15});
   expectedWritten.push_back({h8});
 
   // FMLA S9, S2, Q20
-  expectedRead.push_back({s2,s9,q20});
+  expectedRead.push_back({s2, s9, q20});
   expectedWritten.push_back({s9});
 
   // FMLS D8, D5, D17
-  expectedRead.push_back({d5,d8,d17});
+  expectedRead.push_back({d5, d8, d17});
   expectedWritten.push_back({d8});
 
   // TBL Q4, Q8, Q9
-  expectedRead.push_back({q8,q9});
+  expectedRead.push_back({q8, q9});
   expectedWritten.push_back({q4});
 
   // TBX D0, D1, D2, D3
-  expectedRead.push_back({d1,d2,d3});
+  expectedRead.push_back({d1, d2, d3});
   expectedWritten.push_back({d0});
 
   // TBL Q0, Q24, Q25, Q26, Q31
-  expectedRead.push_back({q24,q25,q26,q31});
+  expectedRead.push_back({q24, q25, q26, q31});
   expectedWritten.push_back({q0});
 
   // TBX D20, D0, D1, D2, D3, D21
-  expectedRead.push_back({d0,d1,d2,d3,d21});
+  expectedRead.push_back({d0, d1, d2, d3, d21});
   expectedWritten.push_back({d20});
 
   // SADDL Q1, HQ2, HQ3
-  expectedRead.push_back({hq2,hq3});
+  expectedRead.push_back({hq2, hq3});
   expectedWritten.push_back({q1});
 
   // SSUBL Q31, D4, D5
-  expectedRead.push_back({d4,d5});
+  expectedRead.push_back({d4, d5});
   expectedWritten.push_back({q31});
 
   // ADDHN HQ2, Q8, Q16
-  expectedRead.push_back({q8,q16});
+  expectedRead.push_back({q8, q16});
   expectedWritten.push_back({hq2});
 
   // SABDL Q5, D2, D8
-  expectedRead.push_back({d2,d8});
+  expectedRead.push_back({d2, d8});
   expectedWritten.push_back({q5});
 
   // SQDMLSL Q0, HQ1, HQ2
-  expectedRead.push_back({hq1,hq2});
+  expectedRead.push_back({hq1, hq2});
   expectedWritten.push_back({q0});
 
   // RSUBHN D2, Q15, Q31
-  expectedRead.push_back({q15,q31});
+  expectedRead.push_back({q15, q31});
   expectedWritten.push_back({d2});
 
   // SUBHN HQ8, Q2,Q3
-  expectedRead.push_back({q2,q3});
+  expectedRead.push_back({q2, q3});
   expectedWritten.push_back({hq8});
 
   // SQADD D2, D3, D5
-  expectedRead.push_back({d3,d5});
+  expectedRead.push_back({d3, d5});
   expectedWritten.push_back({d2});
 
   // CMGT Q0, Q1, Q31
-  expectedRead.push_back({q1,q31});
+  expectedRead.push_back({q1, q31});
   expectedWritten.push_back({q0});
 
   // SABA D8, D9, D10
-  expectedRead.push_back({d9,d10});
+  expectedRead.push_back({d9, d10});
   expectedWritten.push_back({d8});
 
   // BSL Q4, Q5, Q6
-  expectedRead.push_back({q5,q6});
+  expectedRead.push_back({q5, q6});
   expectedWritten.push_back({q4});
 
   // CNT D8, D9
@@ -804,123 +807,123 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedWritten.push_back({d31});
 
   // SMLAL Q2, D5, D0
-  expectedRead.push_back({d5,d0,q2});
+  expectedRead.push_back({d5, d0, q2});
   expectedWritten.push_back({q2});
 
   // SMLSL Q1, HQ31, Q5
-  expectedRead.push_back({q1,hq31,q5});
+  expectedRead.push_back({q1, hq31, q5});
   expectedWritten.push_back({q1});
 
   // MUL Q9, Q2, D31
-  expectedRead.push_back({q2,d31});
+  expectedRead.push_back({q2, d31});
   expectedWritten.push_back({q9});
 
   // SQDMULL Q8, D4, Q5
-  expectedRead.push_back({d4,q5});
+  expectedRead.push_back({d4, q5});
   expectedWritten.push_back({q8});
 
   // SQRDMULH D1. D2, D3
-  expectedRead.push_back({d2,d3});
+  expectedRead.push_back({d2, d3});
   expectedWritten.push_back({d1});
 
   // FMLS Q5, Q10, Q11
-  expectedRead.push_back({q5,q10,q11});
+  expectedRead.push_back({q5, q10, q11});
   expectedWritten.push_back({q5});
 
   // UMLAL Q4, HQ8, D31
-  expectedRead.push_back({q4,hq8,d31});
+  expectedRead.push_back({q4, hq8, d31});
   expectedWritten.push_back({q4});
 
   // FMLA D4, D12, Q8
-  expectedRead.push_back({d4,d12,q8});
+  expectedRead.push_back({d4, d12, q8});
   expectedWritten.push_back({d4});
 
   // ST1 Q4, [X8]
-  expectedRead.push_back({q4,x8});
+  expectedRead.push_back({q4, x8});
   expectedWritten.push_back({});
 
   // ST2 D9, D10, [SP]
-  expectedRead.push_back({d9,d10,sp});
+  expectedRead.push_back({d9, d10, sp});
   expectedWritten.push_back({});
 
   // ST1 Q2, Q3, [X30]
-  expectedRead.push_back({q2,q3,x30});
+  expectedRead.push_back({q2, q3, x30});
   expectedWritten.push_back({});
 
   // LD1 Q30, Q31, Q0, [SP]
   expectedRead.push_back({sp});
-  expectedWritten.push_back({q0,q30,q31});
+  expectedWritten.push_back({q0, q30, q31});
 
   // LD1 D1, D2, D3, D4, [X0]
   expectedRead.push_back({x0});
-  expectedWritten.push_back({d1,d2,d3,d4});
+  expectedWritten.push_back({d1, d2, d3, d4});
 
   // LD3 Q5, Q6, Q7, [X1]
   expectedRead.push_back({x1});
-  expectedWritten.push_back({q5,q6,q7});
+  expectedWritten.push_back({q5, q6, q7});
 
   // ST4 D0, D1, D2, D3, [X2], X20
-  expectedRead.push_back({x2,x20,d0,d1,d2,d3});
+  expectedRead.push_back({x2, x20, d0, d1, d2, d3});
   expectedWritten.push_back({x2});
 
   // ST1 Q30, Q31, Q0, Q1, [SP], X5
-  expectedRead.push_back({q30,q31,q0,q1,sp,x5});
+  expectedRead.push_back({q30, q31, q0, q1, sp, x5});
   expectedWritten.push_back({sp});
 
   // ST1 Q4, Q5, Q6, [X8], X7
-  expectedRead.push_back({q4,q5,q6,x7,x8});
+  expectedRead.push_back({q4, q5, q6, x7, x8});
   expectedWritten.push_back({x8});
 
   // LD1 D31, D0, [SP], X30
-  expectedRead.push_back({sp,x30});
-  expectedWritten.push_back({d0,d31,sp});
+  expectedRead.push_back({sp, x30});
+  expectedWritten.push_back({d0, d31, sp});
 
   // LD1 Q5, [X10], X0
-  expectedRead.push_back({x10,x0});
-  expectedWritten.push_back({q5,x10});
+  expectedRead.push_back({x10, x0});
+  expectedWritten.push_back({q5, x10});
 
   // ST3 D5, D6, D7, [SP], #24
-  expectedRead.push_back({d5,d6,d7,sp});
+  expectedRead.push_back({d5, d6, d7, sp});
   expectedWritten.push_back({sp});
 
   // ST1 Q31, Q0, Q1, Q2, [X2], #48
-  expectedRead.push_back({q0,q1,q2,q31,x2});
+  expectedRead.push_back({q0, q1, q2, q31, x2});
   expectedWritten.push_back({x2});
 
   // LD1 Q1, Q2, Q3, [SP], #48
   expectedRead.push_back({sp});
-  expectedWritten.push_back({q1,q2,q3,sp});
+  expectedWritten.push_back({q1, q2, q3, sp});
 
   // LD1 D31, D0, [X30], #16
   expectedRead.push_back({x30});
-  expectedWritten.push_back({d0,d31,x30});
+  expectedWritten.push_back({d0, d31, x30});
 
   // ST1 Q4, [X0], #16
-  expectedRead.push_back({q4,x0});
+  expectedRead.push_back({q4, x0});
   expectedWritten.push_back({x0});
 
   // ST1 Q5, [X2]
-  expectedRead.push_back({q5,x2});
+  expectedRead.push_back({q5, x2});
   expectedWritten.push_back({});
 
   // ST2 D4, D5, [SP]
-  expectedRead.push_back({d4,d5,sp});
+  expectedRead.push_back({d4, d5, sp});
   expectedWritten.push_back({});
 
   // ST3 Q31, Q0, Q1, [X8]
-  expectedRead.push_back({q0,q1,q31,x8});
+  expectedRead.push_back({q0, q1, q31, x8});
   expectedWritten.push_back({});
 
   // ST4 D0, D1, D2, D3, [SP]
-  expectedRead.push_back({d0,d1,d2,d3,sp});
+  expectedRead.push_back({d0, d1, d2, d3, sp});
   expectedWritten.push_back({});
 
   // ST2 Q21, Q22, [X30]
-  expectedRead.push_back({q21,q22,x30});
+  expectedRead.push_back({q21, q22, x30});
   expectedWritten.push_back({});
 
   // ST4 D30, D31, D0, D1, [X0]
-  expectedRead.push_back({d0,d1,d30,d31,x0});
+  expectedRead.push_back({d0, d1, d30, d31, x0});
   expectedWritten.push_back({});
 
   // LD1 Q5, [X2]
@@ -929,15 +932,15 @@ test_results_t aarch64_simd_Mutator::executeTest()
 
   // LD2 D4, D5, [SP]
   expectedRead.push_back({sp});
-  expectedWritten.push_back({d4,d5});
+  expectedWritten.push_back({d4, d5});
 
   // LD3 Q31, Q0, Q1, [X8]
   expectedRead.push_back({x8});
-  expectedWritten.push_back({q0,q1,q31});
+  expectedWritten.push_back({q0, q1, q31});
 
   // LD4 D0, D1, D2, D3, [SP]
   expectedRead.push_back({sp});
-  expectedWritten.push_back({d0,d1,d2,d3});
+  expectedWritten.push_back({d0, d1, d2, d3});
 
   // LD1 D9, [X0]
   expectedRead.push_back({x0});
@@ -945,39 +948,39 @@ test_results_t aarch64_simd_Mutator::executeTest()
 
   // LD3 Q1, Q2, Q3, [X1]
   expectedRead.push_back({x1});
-  expectedWritten.push_back({q1,q2,q3});
+  expectedWritten.push_back({q1, q2, q3});
 
   // ST1 Q5, [X2], X8
-  expectedRead.push_back({q5,x2,x8});
+  expectedRead.push_back({q5, x2, x8});
   expectedWritten.push_back({x2});
 
   // ST2 D4, D5, [SP], #4
-  expectedRead.push_back({d4,d5,sp});
+  expectedRead.push_back({d4, d5, sp});
   expectedWritten.push_back({sp});
 
   // ST3 Q31, Q0, Q1, [X8], X30
-  expectedRead.push_back({q0,q1,q31,x8,x30});
+  expectedRead.push_back({q0, q1, q31, x8, x30});
   expectedWritten.push_back({x8});
 
   // ST4 D0, D1, D2, D3, [SP], #32
-  expectedRead.push_back({d0,d1,d2,d3,sp});
+  expectedRead.push_back({d0, d1, d2, d3, sp});
   expectedWritten.push_back({sp});
 
   // LD1 Q5,[X2], #1
   expectedRead.push_back({x2});
-  expectedWritten.push_back({q5,x2});
+  expectedWritten.push_back({q5, x2});
 
   // LD2 D4, D5, [SP], X0
-  expectedRead.push_back({sp,x0});
-  expectedWritten.push_back({sp,d4,d5});
+  expectedRead.push_back({sp, x0});
+  expectedWritten.push_back({sp, d4, d5});
 
   // LD3 Q31, Q0, Q1, [X8], #12
   expectedRead.push_back({x8});
-  expectedWritten.push_back({q0,q1,q31,x8});
+  expectedWritten.push_back({q0, q1, q31, x8});
 
   // LD4 D0, D1, D2, D3, [SP], X9
-  expectedRead.push_back({sp,x9});
-  expectedWritten.push_back({d0,d1,d2,d3,sp});
+  expectedRead.push_back({sp, x9});
+  expectedWritten.push_back({d0, d1, d2, d3, sp});
 
   // SSHR D2, D4, #8
   expectedRead.push_back({d4});
@@ -1011,14 +1014,26 @@ test_results_t aarch64_simd_Mutator::executeTest()
   expectedRead.push_back({q5});
   expectedWritten.push_back({q2});
 
+  if(expectedRead.size() != expectedWritten.size()) {
+    logerror("FATAL: expectedRead.size() != expectedWritten.size()");
+    return FAILED;
+  }
+
+  if(expectedRead.size() != decodedInsns.size()) {
+    logerror("FATAL: expectedRead.size() != decodedInsns.size()");
+    return FAILED;
+  }
+
   test_results_t retVal = PASSED;
-  for(auto insn : decodedInsns) {
-    auto status = verify_read_write_sets(insn, expectedRead.front(), expectedWritten.front());
+  for(auto&& x : boost::combine(decodedInsns, expectedRead, expectedWritten)) {
+    auto insn = x.get<0>();
+    auto read = x.get<1>();
+    auto written = x.get<2>();
+
+    auto status = verify_read_write_sets(insn, read, written);
     if(status == FAILED) {
       retVal = FAILED;
     }
-    expectedRead.pop_front();
-    expectedWritten.pop_front();
   }
 
   return retVal;

--- a/src/instruction/fucompp.C
+++ b/src/instruction/fucompp.C
@@ -1,118 +1,235 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "Architecture.h"
+#include "Instruction.h"
 #include "instruction_comp.h"
+#include "InstructionDecoder.h"
+#include "registers/x86_regs.h"
 #include "test_lib.h"
 
-#include "Instruction.h"
-#include "InstructionDecoder.h"
-#include <boost/assign/list_of.hpp>
-#include <deque>
-#include "Architecture.h"
-#include "registers/x86_regs.h"
+#include <array>
+#include <boost/range/combine.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <vector>
 
-using namespace Dyninst;
-using namespace InstructionAPI;
-using namespace boost;
-using namespace boost::assign;
-
-using namespace std;
+namespace di = Dyninst::InstructionAPI;
 
 class fucompp_Mutator : public InstructionMutator {
-    public:
-        fucompp_Mutator() { };
-        virtual test_results_t executeTest();
+public:
+  fucompp_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* fucompp_factory()
-{
-    return new fucompp_Mutator();
+extern "C" DLLEXPORT TestMutator* fucompp_factory() {
+  return new fucompp_Mutator();
 }
 
+test_results_t fucompp_Mutator::executeTest() {
+  constexpr auto num_tests = 24;
 
-test_results_t fucompp_Mutator::executeTest()
-{
-    const unsigned char buffer[] =
-    {
-        0xDA, 0xE9
-    };
-    unsigned int size = 2;
-    unsigned int expectedInsns = 2;
-    InstructionDecoder d(buffer, size, Dyninst::Arch_x86);
-    std::deque<Instruction> decodedInsns;
-    Instruction i;
-    do
-    {
-        i = d.decode();
-        decodedInsns.push_back(i);
-    }
-    while(i.isValid());
-    if(decodedInsns.size() != expectedInsns)
-    {
-        logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-        for(std::deque<Instruction>::iterator curInsn = decodedInsns.begin();
-            curInsn != decodedInsns.end();
-            ++curInsn)
-        {
-            logerror("\t%s\n", curInsn->format().c_str());
-        }
-    
-        return FAILED;
-    }
-    if(decodedInsns.back().isValid())
-    {
-        logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
-        return FAILED;
-    }
-  
-    Architecture curArch = Arch_x86;
-    registerSet expectedRead, expectedWritten;
-    test_results_t retVal = PASSED;
-    {
-        using namespace x86;
-  
-        RegisterAST::Ptr r_st0(new RegisterAST(st0));
-        RegisterAST::Ptr r_st1(new RegisterAST(st1));
+  // clang-format off
+  constexpr std::array<const uint8_t, 52> buffer = {
+      // ordered comparisons
+      0xd8, 0x55, 0x00,   // fcom dword ptr [ebp]
+      0xdc, 0x55, 0x00,   // fcom qword ptr [ebp]
+      0xd8, 0xd0,         // fcom st0
+      0xd8, 0xd1,         // fcom st1
+      0xd8, 0xd2,         // fcom st2
+      0xd8, 0x5d, 0x00,   // fcomp dword ptr [ebp]
+      0xdc, 0x5d, 0x00,   // fcomp qword ptr [ebp]
+      0xd8, 0xd8,         // fcomp st0
+      0xd8, 0xd9,         // fcomp st1
+      0xd8, 0xda,         // fcomp st2
+      0xde, 0xd9,         // fcompp
 
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-        expectedRead = { r_st0, r_st1 };
-        expectedWritten = { r_st0, r_st1 };
-#else
-        expectedRead = list_of(r_st0)(r_st1);
-        expectedWritten = list_of(r_st0)(r_st1);
-#endif  
-  
-        retVal = failure_accumulator(retVal, verify_read_write_sets(decodedInsns.front(), expectedRead, expectedWritten));
-        decodedInsns.pop_front();
-  
+      // compare and set eflags
+      0xdb, 0xf0,         // fcomi st0, st0
+      0xdf, 0xf0,         // fcomip st0, st0
+      0xdf, 0xf1,         // fcomip st0, st1
+      0xdb, 0xe8,         // fucomi st0, st0
+      0xdb, 0xe9,         // fucomi st0, st1
+      0xdf, 0xe8,         // fucomip st0, st0
+      0xdf, 0xe9,         // fucomip st0, st1
+
+      // unordered comparisons
+      0xdd, 0xe0,     // fucom st0
+      0xdd, 0xe1,     // fucom st1 (aka, 'fucom')
+      0xdd, 0xe2,     // fucom st2
+      0xdd, 0xe8,     // fucomp
+      0xdd, 0xe9,     // fucompp
+      0xdd, 0xea,     // fucomp st2
+  };
+  // clang-format on
+
+  std::vector<di::Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_x86);
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode x86 test %d\n", idx + 1);
+      return FAILED;
     }
-    return retVal;
+    decodedInsns.push_back(insn);
+  }
+
+  auto create = [](Dyninst::MachRegister reg) {
+    return boost::make_shared<di::RegisterAST>(reg);
+  };
+
+  di::RegisterAST::Ptr st0 = create(Dyninst::x86::st0);
+  di::RegisterAST::Ptr st1 = create(Dyninst::x86::st1);
+  di::RegisterAST::Ptr st2 = create(Dyninst::x86::st2);
+  di::RegisterAST::Ptr ebp = create(Dyninst::x86::ebp);
+
+  std::vector<registerSet> expectedRead, expectedWritten;
+
+  // fcom dword ptr [ebp]
+  expectedRead.push_back({st0, ebp});
+  expectedWritten.push_back({st0});
+
+  // fcom qword ptr [ebp]
+  expectedRead.push_back({st0, ebp});
+  expectedWritten.push_back({st0});
+
+  // fcom st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fcom st1
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fcom st2
+  expectedRead.push_back({st0, st2});
+  expectedWritten.push_back({st0});
+
+  // fcomp dword ptr [ebp]
+  expectedRead.push_back({st0, ebp});
+  expectedWritten.push_back({st0});
+
+  // fcomp qword ptr [ebp]
+  expectedRead.push_back({st0, ebp});
+  expectedWritten.push_back({st0});
+
+  // fcomp st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fcomp st1
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fcomp st2
+  expectedRead.push_back({st0, st2});
+  expectedWritten.push_back({st0});
+
+  // fcompp
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fcomi st0, st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fcomip st0, st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fcomip st0, st1
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fucomi st0, st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fucomi st0, st1
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fucomip st0, st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fucomip st0, st1
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fucom st0
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({});
+
+  // fucom st1 (aka, 'fucom')
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({});
+
+  // fucom st2
+  expectedRead.push_back({st0, st2});
+  expectedWritten.push_back({});
+
+  // fucomp
+  expectedRead.push_back({st0});
+  expectedWritten.push_back({st0});
+
+  // fucompp
+  expectedRead.push_back({st0, st1});
+  expectedWritten.push_back({st0});
+
+  // fucomp st(3)
+  expectedRead.push_back({st0, st2});
+  expectedWritten.push_back({st0});
+
+  if(expectedRead.size() != expectedWritten.size()) {
+    logerror("FATAL: expectedRead.size() != expectedWritten.size()");
+    return FAILED;
+  }
+
+  if(expectedRead.size() != decodedInsns.size()) {
+    logerror("FATAL: expectedRead.size() != decodedInsns.size()");
+    return FAILED;
+  }
+
+  test_results_t retVal = PASSED;
+  for(auto&& x : boost::combine(decodedInsns, expectedRead, expectedWritten)) {
+    auto insn = x.get<0>();
+    auto read = x.get<1>();
+    auto written = x.get<2>();
+
+    auto status = verify_read_write_sets(insn, read, written);
+    if(status == FAILED) {
+      retVal = FAILED;
+    }
+  }
+  return retVal;
 }
-

--- a/src/instruction/mov_size_details.C
+++ b/src/instruction/mov_size_details.C
@@ -1,113 +1,122 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "Instruction.h"
 #include "instruction_comp.h"
+#include "InstructionDecoder.h"
 #include "test_lib.h"
 
-#include "Instruction.h"
-#include "InstructionDecoder.h"
-#include <boost/assign/list_of.hpp>
-#include <deque>
-using namespace Dyninst;
-using namespace InstructionAPI;
-using namespace boost;
-using namespace boost::assign;
+#include <boost/range/combine.hpp>
+#include <tuple>
+#include <vector>
 
-using namespace std;
+namespace di = Dyninst::InstructionAPI;
 
 class mov_size_details_Mutator : public InstructionMutator {
 public:
-   mov_size_details_Mutator() { };
-   virtual test_results_t executeTest();
+  mov_size_details_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* mov_size_details_factory()
-{
-   return new mov_size_details_Mutator();
+extern "C" DLLEXPORT TestMutator* mov_size_details_factory() {
+  return new mov_size_details_Mutator();
 }
 
+test_results_t mov_size_details_Mutator::executeTest() {
+  constexpr auto num_tests = 5;
 
-test_results_t mov_size_details_Mutator::executeTest()
-{
-  const unsigned char buffer[] = 
-  {
-    0x66, 0x8c, 0xe8
+  // clang-format off
+  constexpr std::array<const uint8_t, 16> buffer = {
+    0x66, 0x8c, 0xe8,               // mov ax, gs
+    0x89, 0xe8,                     // mov eax, ebp
+    0xf2, 0x0f, 0x12, 0xc0,         // movddup xmm0, xmm0
+    0x05, 0xef, 0xbe, 0xad, 0xde,   // add eax, 0xdeadbeef
+    0xd8, 0xd8,                     // fcomp st0, st0
   };
-  unsigned int size = 3;
-  unsigned int expectedInsns = 2;
-  InstructionDecoder d(buffer, size, Dyninst::Arch_x86);
-  std::deque<Instruction> decodedInsns;
-  Instruction i;
-  do
-  {
-    i = d.decode();
-    decodedInsns.push_back(i);
-  }
-  while(i.isValid());
-  if(decodedInsns.size() != expectedInsns)
-  {
-    logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-    for(std::deque<Instruction>::iterator curInsn = decodedInsns.begin();
-	curInsn != decodedInsns.end();
-	++curInsn)
-    {
-      logerror("\t%s\n", curInsn->format().c_str());
+  // clang-format on
+
+  std::vector<di::Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+
+  di::InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_x86);
+  for(int idx = 0; idx < num_tests; idx++) {
+    di::Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode x86 test %d\n", idx + 1);
+      return FAILED;
     }
-    
-    return FAILED;
+    decodedInsns.push_back(insn);
   }
-  if(decodedInsns.back().isValid())
-  {
-    logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
-    return FAILED;
-  }
-  
-  Architecture curArch = Arch_x86;
-  Instruction mov = decodedInsns.front();
 
-  Expression::Ptr lhs, rhs;
-  lhs = mov.getOperand(0).getValue();
-  rhs = mov.getOperand(1).getValue();
-  
-  if(lhs->size() != 2)
-  {
-    logerror("LHS expected 16-bit, actual %d-bit (%s)\n", lhs->size() * 8, lhs->format().c_str());
-    return FAILED;
-  }
-  if(rhs->size() != 2)
-  {
-    logerror("RHS expected 16-bit, actual %d-bit (%s)\n", rhs->size() * 8, rhs->format().c_str());
+  std::vector<std::tuple<int, int>> expected_sizes;
+
+  // mov ax, gs
+  expected_sizes.push_back({2, 2});
+
+  // mov eax, ebp
+  expected_sizes.push_back({4, 4});
+
+  // movddup xmm0, xmm0
+  expected_sizes.push_back({16, 16});
+
+  // add eax, 0xdeadbeef
+  expected_sizes.push_back({4, 4});
+
+  // fcomp st0, st0
+  expected_sizes.push_back({8, 8}); // wrong. should be 80 bits
+
+  if(decodedInsns.size() != expected_sizes.size()) {
+    logerror("FATAL: decodedInsns.size() != expected_sizes.size()");
     return FAILED;
   }
 
+  auto ret_val = PASSED;
+  for(auto&& x : boost::combine(decodedInsns, expected_sizes)) {
+    const auto insn = x.get<0>();
+    const auto sizes = x.get<1>();
 
-  return PASSED;
+    const auto lhs_size = std::get<0>(sizes);
+    const auto rhs_size = std::get<1>(sizes);
+
+    di::Expression::Ptr lhs = insn.getOperand(0).getValue();
+    di::Expression::Ptr rhs = insn.getOperand(1).getValue();
+
+    if(lhs->size() != lhs_size) {
+      logerror("LHS expected %d-bit, actual %d-bit (%s)\n", lhs_size * 8, lhs->size() * 8, lhs->format().c_str());
+      ret_val = FAILED;
+    }
+    if(rhs->size() != rhs_size) {
+      logerror("RHS expected %d-bit, actual %d-bit (%s)\n", rhs_size, rhs->size() * 8, rhs->format().c_str());
+      ret_val = FAILED;
+    }
+  }
+  return ret_val;
 }
-

--- a/src/instruction/power_cft.C
+++ b/src/instruction/power_cft.C
@@ -1,198 +1,254 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "instruction_comp.h"
-#include "test_lib.h"
-
 #include "Instruction.h"
+#include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
 #include "registers/ppc32_regs.h"
-#include <boost/assign/list_of.hpp>
-#include <boost/iterator/indirect_iterator.hpp>
-#include <deque>
+#include "registers/ppc64_regs.h"
+#include "test_lib.h"
+
+#include <array>
+#include <boost/range/combine.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <tuple>
+#include <vector>
+
 using namespace Dyninst;
 using namespace InstructionAPI;
-using namespace boost;
-using namespace boost::assign;
-
-using namespace std;
 
 class power_cft_Mutator : public InstructionMutator {
+  test_results_t run(Dyninst::Architecture);
+
 public:
-    power_cft_Mutator() { };
-   virtual test_results_t executeTest();
+  power_cft_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* power_cft_factory()
-{
-   return new power_cft_Mutator();
+extern "C" DLLEXPORT TestMutator* power_cft_factory() {
+  return new power_cft_Mutator();
 }
 
-struct cftExpected
-{
-    bool defined;
-    unsigned int expected;
-    bool call;
-    bool conditional;
-    bool indirect;
-    bool fallthrough;
-    cftExpected(bool d, unsigned int e, bool isCall, bool isCond, bool isIndir, bool isFT) :
-            defined(d), expected(e), call(isCall), conditional(isCond), indirect(isIndir),
-            fallthrough(isFT) {}
+struct cftExpected {
+  bool defined;
+  unsigned int expected;
+  bool call;
+  bool conditional;
+  bool indirect;
+  bool fallthrough;
 };
 
-test_results_t verifyTargetType(const Instruction::CFT& actual, const cftExpected& expected)
-{
-    if(actual.isCall != expected.call) {
-        logerror("FAILED: expected call = %d, actual = %d\n", expected.call, actual.isCall);
-        return FAILED;
-    }
-    if(actual.isIndirect != expected.indirect) {
-        logerror("FAILED: expected indirect = %d, actual = %d\n", expected.indirect, actual.isIndirect);
-        return FAILED;
-    }
-    if(actual.isConditional != expected.conditional) {
-        logerror("FAILED: expected conditional = %d, actual = %d\n", expected.conditional, actual.isConditional);
-        return FAILED;
-    }
-    if(actual.isFallthrough != expected.fallthrough) {
-        logerror("FAILED: expected fallthrough = %d, actual = %d\n", expected.fallthrough, actual.isFallthrough);
-        return FAILED;
-    }
-    return PASSED;
+test_results_t verifyTargetType(const Instruction::CFT& actual, const cftExpected& expected) {
+  if(actual.isCall != expected.call) {
+    logerror("FAILED: expected call = %d, actual = %d\n", expected.call, actual.isCall);
+    return FAILED;
+  }
+  if(actual.isIndirect != expected.indirect) {
+    logerror("FAILED: expected indirect = %d, actual = %d\n", expected.indirect, actual.isIndirect);
+    return FAILED;
+  }
+  if(actual.isConditional != expected.conditional) {
+    logerror("FAILED: expected conditional = %d, actual = %d\n", expected.conditional, actual.isConditional);
+    return FAILED;
+  }
+  if(actual.isFallthrough != expected.fallthrough) {
+    logerror("FAILED: expected fallthrough = %d, actual = %d\n", expected.fallthrough, actual.isFallthrough);
+    return FAILED;
+  }
+  return PASSED;
 }
 
-test_results_t power_cft_Mutator::executeTest()
-{
-  const uint32_t buffer[] = 
-  {
-        0x48000010, // b +16                     
-        0x42f00020, // b +32
-        0x4ef00420, // bctr
-        0x42f00022, // b 32
-        0x42f0ffd0, // b -32
-        0x4ef00020, // blr
-        0x40010101, // bdnzl cr0, +0x100
-        0x40010100, // bdnz cr0, +0x100
-        0x4ef00421, // bctrl
-        0x4ca30020, // bnslr+
+namespace {
+  struct test_insn {
+    const uint32_t opcode;
+    std::vector<cftExpected> expected_targets;
   };
-  unsigned int expectedInsns = 10;
-  unsigned int size = expectedInsns * 4;
-  ++expectedInsns;
-  InstructionDecoder d(buffer, size, Dyninst::Arch_ppc32);
-  
-  std::deque<Instruction> decodedInsns;
-  Instruction i;
-  do
-  {
-    i = d.decode();
-    decodedInsns.push_back(i);
-  }
-  while(i.isValid());
-  if(decodedInsns.size() != expectedInsns)
-  {
-    logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-    for(std::deque<Instruction>::iterator curInsn = decodedInsns.begin();
-	curInsn != decodedInsns.end();
-	++curInsn)
+
+  // clang-format off
+  auto tests = std::vector<test_insn> {
     {
-        logerror("\t%s\n", curInsn->format().c_str());
+      //  b +16
+      {0x48000010},
+      {
+        {true, 0x410, false, false, false, false},
+      }
+    },
+    {
+      //  b +32
+      {0x42f00020},
+      {
+        {true, 0x420, false, false, false, false},
+      }
+    },
+    {
+      //  bctr
+      {0x4ef00420},
+      {
+        {true, 44, false, false, true, false},
+      }
+    },
+    {
+      //  b 32
+      {0x42f00022},
+      {
+        {true, 0x20, false, false, false, false},
+      }
+    },
+    {
+      //  b -32
+      {0x42f0ffd0},
+      {
+        {true, 0x3d0, false, false, false, false},
+      }
+    },
+    {
+      //  blr
+      {0x4ef00020},
+      {
+        {true, 0x200, false, false, true, false},
+      }
+    },
+    {
+      //  bdnzl cr0
+      {0x40010101},
+      {
+        {true, 0x500, true, true, false, false},
+        {true, 0x404, false, false, false, true},
+      }
+    },
+    {
+      //  bdnz cr0
+      {0x40010100},
+      {
+        {true, 0x500, false, true, false, false},
+        {true, 0x404, false, false, false, true},
+      }
+    },
+    {
+      //  bctrl
+      {0x4ef00421},
+      {
+        {true, 44, true, false, true, false},
+      }
+    },
+    {
+      //  bnslr+
+      {0x4ca30020},
+      {
+        {true, 0x200, false, true, true, false},
+        {true, 0x404, false, false, false, true},
+      }
     }
-    
-    return FAILED;
-  }
-  if(decodedInsns.back().isValid())
+  };
+  // clang-format on
+}
+
+test_results_t power_cft_Mutator::executeTest() {
+  auto ret_val = PASSED;
   {
-    logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
-    return FAILED;
+    logerror("**** Running ppc32 ********\n");
+    const auto status = this->run(Dyninst::Arch_ppc32);
+    if(status == FAILED) {
+      ret_val = FAILED;
+    }
   }
+  {
+    logerror("**** Running ppc64 ********\n");
+    const auto status = this->run(Dyninst::Arch_ppc64);
+    if(status == FAILED) {
+      ret_val = FAILED;
+    }
+  }
+  return ret_val;
+}
+
+test_results_t power_cft_Mutator::run(Dyninst::Architecture arch) {
+  const auto is_64 = (arch == Dyninst::Arch_ppc64);
+
+  RegisterAST::Ptr pc(new RegisterAST(is_64 ? ppc64::pc : ppc32::pc));
+  RegisterAST::Ptr ctr(new RegisterAST(is_64 ? ppc64::ctr : ppc32::ctr));
+  RegisterAST::Ptr lr(new RegisterAST(is_64 ? ppc64::lr : ppc32::lr));
 
   test_results_t retVal = PASSED;
-  
-  decodedInsns.pop_back();
-  Expression* theIP = new RegisterAST(ppc32::pc);
-  Expression* count_reg = new RegisterAST(ppc32::ctr);
-  Expression* link_reg = new RegisterAST(ppc32::lr);
-  
+  auto test_id = 0;
 
-  std::list<cftExpected> cfts;
-  cfts.push_back(cftExpected(true, 0x410, false, false, false, false));
-  cfts.push_back(cftExpected(true, 0x420, false, false, false, false));
-  cfts.push_back(cftExpected(true, 44, false, false, true, false));
-  cfts.push_back(cftExpected(true, 0x20, false, false, false, false));
-  cfts.push_back(cftExpected(true, 0x3d0, false, false, false, false));
-  cfts.push_back(cftExpected(true, 0x200, false, false, true, false));
-  cfts.push_back(cftExpected(true, 0x500, true, true, false, false));
-  cfts.push_back(cftExpected(true, 0x404, false, false, false, true));
-  cfts.push_back(cftExpected(true, 0x500, false, true, false, false));
-  cfts.push_back(cftExpected(true, 0x404, false, false, false, true));
-  cfts.push_back(cftExpected(true, 44, true, false, true, false));
-  cfts.push_back(cftExpected(true, 0x200, false, true, true, false));
-  cfts.push_back(cftExpected(true, 0x404, false, false, false, true));
-  while(!decodedInsns.empty())
-  {
-      logerror("Parsing instruction '%s'\n", decodedInsns.front().format().c_str());
-      (void)(decodedInsns.front().getControlFlowTarget());
-      for(Instruction::cftConstIter curCFT = decodedInsns.front().cft_begin();
-          curCFT != decodedInsns.front().cft_end();
-          ++curCFT)
-      {
-          Expression::Ptr theCFT = curCFT->target;
-          if(theCFT)
-          {
-              theCFT->bind(theIP, Result(u32, 0x400));
-              theCFT->bind(count_reg, Result(u32, 44));
-              theCFT->bind(link_reg, Result(u32, 0x200));
-              retVal = failure_accumulator(retVal, verifyCFT(theCFT, cfts.front().defined, cfts.front().expected, u32));
-              retVal = failure_accumulator(retVal, verifyTargetType(*curCFT, cfts.front()));
-          }
-          else
-          {
-              logerror("FAILED: instruction %s expected CFT, wasn't present", decodedInsns.front().format().c_str());
-              retVal = failure_accumulator(retVal, FAILED);
-          }
-          if(!cfts.empty()) {
-            cfts.pop_front();
-          }
+  for(auto&& t : tests) {
+    test_id++;
+
+    InstructionDecoder d(&(t.opcode), 4, arch);
+    Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode test %d\n", test_id);
+      retVal = FAILED;
+      continue;
+    }
+
+    const auto num_cft = std::distance(insn.cft_begin(), insn.cft_end());
+    const auto num_expected_cft = t.expected_targets.size();
+
+    if(num_cft != num_expected_cft) {
+      logerror("FAILED: Number of targets mismatched for test %d '%s'. Found %u, expected %u\n", test_id,
+               insn.format().c_str(), num_cft, num_expected_cft);
+      retVal = FAILED;
+      continue;
+    }
+
+    auto cft_all = boost::make_iterator_range(insn.cft_begin(), insn.cft_end());
+    for(auto&& cft : boost::combine(cft_all, t.expected_targets)) {
+      Instruction::CFT cft_cur = cft.get<0>();
+      auto target = cft_cur.target;
+
+      if(!target) {
+        logerror("FAILED: No target for '%s'\n", insn.format().c_str());
+        retVal = FAILED;
+        continue;
       }
-      
-      decodedInsns.pop_front();
-  }
 
-  if(!cfts.empty())
-  {
-      logerror("FAILED: didn't consume all expected CFTs, %d remain\n", cfts.size());
-      return FAILED;
+      target->bind(pc.get(), Result(u32, 0x400));
+      target->bind(ctr.get(), Result(u32, 44));
+      target->bind(lr.get(), Result(u32, 0x200));
+
+      cftExpected cft_expected = cft.get<1>();
+
+      auto status = verifyCFT(target, cft_expected.defined, cft_expected.expected, u32);
+      if(status == FAILED) {
+        retVal = FAILED;
+      }
+
+      status = verifyTargetType(cft_cur, cft_expected);
+      if(status == FAILED) {
+        retVal = FAILED;
+      }
+    }
   }
   return retVal;
 }
-

--- a/src/instruction/power_decode.C
+++ b/src/instruction/power_decode.C
@@ -60,7 +60,7 @@ namespace {
   constexpr auto num_tests = 23;
 
   // clang-format off
-  std::array<uint32_t const, num_tests> buffer = {
+  std::array<uint32_t const, 4*num_tests> buffer = {
     0x7d204215, // add. r9, r0, r8
     0x7d204214, // add r9, r0, r8
     0x7d204614, // addo r9, r0, r8

--- a/src/instruction/power_decode.C
+++ b/src/instruction/power_decode.C
@@ -56,7 +56,11 @@ extern "C" DLLEXPORT TestMutator* power_decode_factory() {
   return new power_decode_Mutator();
 }
 
-namespace {
+test_results_t power_decode_Mutator::executeTest() {
+
+  // Decoding in 64-bit mode uses 32-bit registers
+  auto const arch = Dyninst::Arch_ppc32;
+
   constexpr auto num_tests = 23;
 
   // clang-format off
@@ -86,28 +90,7 @@ namespace {
     0x7ca74a6e, // lhzux r9, r7, r5
   };
   // clang-format on
-}
 
-test_results_t power_decode_Mutator::executeTest() {
-  auto ret_val = PASSED;
-  {
-    logerror("**** Running ppc32 ********\n");
-    const auto status = this->run(Dyninst::Arch_ppc32);
-    if(status == FAILED) {
-      ret_val = FAILED;
-    }
-  }
-  {
-    logerror("**** Running ppc64 ********\n");
-    const auto status = this->run(Dyninst::Arch_ppc64);
-    if(status == FAILED) {
-      ret_val = FAILED;
-    }
-  }
-  return ret_val;
-}
-
-test_results_t power_decode_Mutator::run(Dyninst::Architecture arch) {
   std::vector<Instruction> decodedInsns;
   decodedInsns.reserve(num_tests);
 
@@ -123,36 +106,34 @@ test_results_t power_decode_Mutator::run(Dyninst::Architecture arch) {
     }
   }
 
-  const auto is_64 = (arch == Dyninst::Arch_ppc64);
-
-  RegisterAST::Ptr r0(new RegisterAST(is_64 ? ppc64::r0 : ppc32::r0));
-  RegisterAST::Ptr r1(new RegisterAST(is_64 ? ppc64::r1 : ppc32::r1));
-  RegisterAST::Ptr r2(new RegisterAST(is_64 ? ppc64::r2 : ppc32::r2));
-  RegisterAST::Ptr r5(new RegisterAST(is_64 ? ppc64::r5 : ppc32::r5));
-  RegisterAST::Ptr r7(new RegisterAST(is_64 ? ppc64::r7 : ppc32::r7));
-  RegisterAST::Ptr r8(new RegisterAST(is_64 ? ppc64::r8 : ppc32::r8));
-  RegisterAST::Ptr r9(new RegisterAST(is_64 ? ppc64::r9 : ppc32::r9));
-  RegisterAST::Ptr cr0(new RegisterAST(is_64 ? ppc64::cr0 : ppc32::cr0));
-  RegisterAST::Ptr cr2(new RegisterAST(is_64 ? ppc64::cr2 : ppc32::cr2));
-  RegisterAST::Ptr cr4(new RegisterAST(is_64 ? ppc64::cr4 : ppc32::cr4));
-  RegisterAST::Ptr cr6(new RegisterAST(is_64 ? ppc64::cr6 : ppc32::cr6));
-  RegisterAST::Ptr cr7(new RegisterAST(is_64 ? ppc64::cr7 : ppc32::cr7));
-  RegisterAST::Ptr xer(new RegisterAST(is_64 ? ppc64::xer : ppc32::xer));
-  RegisterAST::Ptr fpr0(new RegisterAST(is_64 ? ppc64::fpr0 : ppc32::fpr0));
-  RegisterAST::Ptr fpr1(new RegisterAST(is_64 ? ppc64::fpr1 : ppc32::fpr1));
-  RegisterAST::Ptr fpr2(new RegisterAST(is_64 ? ppc64::fpr2 : ppc32::fpr2));
-  RegisterAST::Ptr fsr0(new RegisterAST(is_64 ? ppc64::fsr0 : ppc32::fsr0));
-  RegisterAST::Ptr fsr1(new RegisterAST(is_64 ? ppc64::fsr1 : ppc32::fsr1));
-  RegisterAST::Ptr fsr2(new RegisterAST(is_64 ? ppc64::fsr2 : ppc32::fsr2));
-  RegisterAST::Ptr fpscw(new RegisterAST(is_64 ? ppc64::fpscw : ppc32::fpscw));
-  RegisterAST::Ptr fpscw0(new RegisterAST(is_64 ? ppc64::fpscw0 : ppc32::fpscw0));
-  RegisterAST::Ptr fpscw2(new RegisterAST(is_64 ? ppc64::fpscw2 : ppc32::fpscw2));
-  RegisterAST::Ptr fpscw4(new RegisterAST(is_64 ? ppc64::fpscw4 : ppc32::fpscw4));
-  RegisterAST::Ptr fpscw6(new RegisterAST(is_64 ? ppc64::fpscw6 : ppc32::fpscw6));
-  RegisterAST::Ptr fpscw7(new RegisterAST(is_64 ? ppc64::fpscw7 : ppc32::fpscw7));
-  RegisterAST::Ptr pc(new RegisterAST(is_64 ? ppc64::pc : ppc32::pc));
-  RegisterAST::Ptr ctr(new RegisterAST(is_64 ? ppc64::ctr : ppc32::ctr));
-  RegisterAST::Ptr lr(new RegisterAST(is_64 ? ppc64::lr : ppc32::lr));
+  RegisterAST::Ptr r0(new RegisterAST(ppc32::r0));
+  RegisterAST::Ptr r1(new RegisterAST(ppc32::r1));
+  RegisterAST::Ptr r2(new RegisterAST(ppc32::r2));
+  RegisterAST::Ptr r5(new RegisterAST(ppc32::r5));
+  RegisterAST::Ptr r7(new RegisterAST(ppc32::r7));
+  RegisterAST::Ptr r8(new RegisterAST(ppc32::r8));
+  RegisterAST::Ptr r9(new RegisterAST(ppc32::r9));
+  RegisterAST::Ptr cr0(new RegisterAST(ppc32::cr0));
+  RegisterAST::Ptr cr2(new RegisterAST(ppc32::cr2));
+  RegisterAST::Ptr cr4(new RegisterAST(ppc32::cr4));
+  RegisterAST::Ptr cr6(new RegisterAST(ppc32::cr6));
+  RegisterAST::Ptr cr7(new RegisterAST(ppc32::cr7));
+  RegisterAST::Ptr xer(new RegisterAST(ppc32::xer));
+  RegisterAST::Ptr fpr0(new RegisterAST(ppc32::fpr0));
+  RegisterAST::Ptr fpr1(new RegisterAST(ppc32::fpr1));
+  RegisterAST::Ptr fpr2(new RegisterAST(ppc32::fpr2));
+  RegisterAST::Ptr fsr0(new RegisterAST(ppc32::fsr0));
+  RegisterAST::Ptr fsr1(new RegisterAST(ppc32::fsr1));
+  RegisterAST::Ptr fsr2(new RegisterAST(ppc32::fsr2));
+  RegisterAST::Ptr fpscw(new RegisterAST(ppc32::fpscw));
+  RegisterAST::Ptr fpscw0(new RegisterAST(ppc32::fpscw0));
+  RegisterAST::Ptr fpscw2(new RegisterAST(ppc32::fpscw2));
+  RegisterAST::Ptr fpscw4(new RegisterAST(ppc32::fpscw4));
+  RegisterAST::Ptr fpscw6(new RegisterAST(ppc32::fpscw6));
+  RegisterAST::Ptr fpscw7(new RegisterAST(ppc32::fpscw7));
+  RegisterAST::Ptr pc(new RegisterAST(ppc32::pc));
+  RegisterAST::Ptr ctr(new RegisterAST(ppc32::ctr));
+  RegisterAST::Ptr lr(new RegisterAST(ppc32::lr));
 
   std::vector<registerSet> expectedRead, expectedWritten;
 

--- a/src/instruction/power_decode.C
+++ b/src/instruction/power_decode.C
@@ -1,455 +1,287 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "instruction_comp.h"
-#include "test_lib.h"
-
 #include "Instruction.h"
+#include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
 #include "registers/ppc32_regs.h"
-#include <boost/assign/list_of.hpp>
-#include <boost/iterator/indirect_iterator.hpp>
-#include <deque>
+#include "registers/ppc64_regs.h"
+#include "test_lib.h"
+
+#include <array>
+#include <boost/range/combine.hpp>
+#include <vector>
+
 using namespace Dyninst;
 using namespace InstructionAPI;
-using namespace boost;
-using namespace boost::assign;
-
-using namespace std;
 
 class power_decode_Mutator : public InstructionMutator {
+  test_results_t run(Dyninst::Architecture);
+
 public:
-    power_decode_Mutator() { };
-   virtual test_results_t executeTest();
+  power_decode_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* power_decode_factory()
-{
-   return new power_decode_Mutator();
+extern "C" DLLEXPORT TestMutator* power_decode_factory() {
+  return new power_decode_Mutator();
 }
 
-test_results_t power_decode_Mutator::executeTest()
-{
-  const uint32_t buffer[] = 
-  {
-      0x7d204215, // add. r9, r0, r8
-      0x7d204214,  // add r9, r0, r8
-      0x7d204614,  // addo r9, r0, r8
-      0xfc01102a, // fadd fpr0, fpr1, fpr2
-      0xfc01102b, // fadd. fpr0, fpr1, fpr2
-      0x38200001, // addi r1, 0, 1
-      0x38210001, // addi r1, r1, 1
-      0xff800800, // fcmpu fpscr7, fpr0, fpr1
-      0x7f800800, // fcmpu cr7, r0, r1
-      0x7c0aa120, // mtcrf cr0, cr2, cr4, cr6, r0
-      0xfd54058e, // mtfsf fpscr0, fpscr2, fpscr4, fpscr6, fpr0
-      0x80010000, // lwz r0, 0(r1)
-      0x84010000, // lwzu r0, 0(r1)
-      0x7c01102e, // lwzx r0, r2(r1)
-      0x7c01106e, // lwzux r0, r2(r1)
-      0x7801440c, // rlimi r0, r1
-      0x00010090, // fpmul fpr0, fpr1
-      0x00010092, // fxmul fpr0, fpr1, or qvfxmadds 
-      0x00010094, // fxcpmul fpr0, fpr1
-      0x00010096, // fxcsmul fpr0, fpr1, or qvfxxnpmadds
-      0x40010101, // bdnzl cr0, +0x100
-      0x40010100, // bdnz cr0, +0x100
-      0x7ca74a6e, // lhzux r9, r7, r5
+namespace {
+  constexpr auto num_tests = 23;
+
+  // clang-format off
+  std::array<uint32_t const, num_tests> buffer = {
+    0x7d204215, // add. r9, r0, r8
+    0x7d204214, // add r9, r0, r8
+    0x7d204614, // addo r9, r0, r8
+    0xfc01102a, // fadd fpr0, fpr1, fpr2
+    0xfc01102b, // fadd. fpr0, fpr1, fpr2
+    0x38200001, // addi r1, 0, 1
+    0x38210001, // addi r1, r1, 1
+    0xff800800, // fcmpu fpscw7, fpr0, fpr1
+    0x7f800800, // fcmpu cr7, r0, r1
+    0x7c0aa120, // mtcrf cr0, cr2, cr4, cr6, r0
+    0xfd54058e, // mtfsf fpscw0, fpscw2, fpscw4, fpscw6, fpr0
+    0x80010000, // lwz r0, 0(r1)
+    0x84010000, // lwzu r0, 0(r1)
+    0x7c01102e, // lwzx r0, r2(r1)
+    0x7c01106e, // lwzux r0, r2(r1)
+    0x7801440c, // rlimi r0, r1
+    0x00010090, // fpmul fpr0, fpr1
+    0x00010092, // fxmul fpr0, fpr1, or qvfxmadds
+    0x00010094, // fxcpmul fpr0, fpr1
+    0x00010096, // fxcsmul fpr0, fpr1, or qvfxxnpmadds
+    0x40010101, // bdnzl cr0, +0x100
+    0x40010100, // bdnz cr0, +0x100
+    0x7ca74a6e, // lhzux r9, r7, r5
   };
-  unsigned int expectedInsns = 23;
-  unsigned int size = expectedInsns * 4;
-  ++expectedInsns;
-  InstructionDecoder d(buffer, size, Dyninst::Arch_ppc32);
-  
-  std::deque<Instruction> decodedInsns;
-  Instruction i;
-  do
+  // clang-format on
+}
+
+test_results_t power_decode_Mutator::executeTest() {
+  auto ret_val = PASSED;
   {
-    i = d.decode();
-    decodedInsns.push_back(i);
-  }
-  while(i.isValid());
-  if(decodedInsns.size() != expectedInsns)
-  {
-    logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-    for(std::deque<Instruction>::iterator curInsn = decodedInsns.begin();
-	curInsn != decodedInsns.end();
-	++curInsn)
-    {
-        logerror("\t%s\n", curInsn->format().c_str());
+    logerror("**** Running ppc32 ********\n");
+    const auto status = this->run(Dyninst::Arch_ppc32);
+    if(status == FAILED) {
+      ret_val = FAILED;
     }
-    
-    return FAILED;
   }
-  if(decodedInsns.back().isValid())
   {
-    logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
-    return FAILED;
+    logerror("**** Running ppc64 ********\n");
+    const auto status = this->run(Dyninst::Arch_ppc64);
+    if(status == FAILED) {
+      ret_val = FAILED;
+    }
   }
-  std::deque<registerSet> expectedRead, expectedWritten;
-  registerSet tmpRead, tmpWritten;
-  RegisterAST::Ptr r0(new RegisterAST(ppc32::r0));
-  RegisterAST::Ptr r1(new RegisterAST(ppc32::r1));
-  RegisterAST::Ptr r2(new RegisterAST(ppc32::r2));
-  RegisterAST::Ptr r5(new RegisterAST(ppc32::r5));
-  RegisterAST::Ptr r7(new RegisterAST(ppc32::r7));
-  RegisterAST::Ptr r8(new RegisterAST(ppc32::r8));
-  RegisterAST::Ptr r9(new RegisterAST(ppc32::r9));
-  RegisterAST::Ptr cr0(new RegisterAST(ppc32::cr0));
-  RegisterAST::Ptr cr2(new RegisterAST(ppc32::cr2));
-  RegisterAST::Ptr cr4(new RegisterAST(ppc32::cr4));
-  RegisterAST::Ptr cr6(new RegisterAST(ppc32::cr6));
-  RegisterAST::Ptr cr7(new RegisterAST(ppc32::cr7));
-  RegisterAST::Ptr xer(new RegisterAST(ppc32::xer));
-  RegisterAST::Ptr fpr0(new RegisterAST(ppc32::fpr0));
-  RegisterAST::Ptr fpr1(new RegisterAST(ppc32::fpr1));
-  RegisterAST::Ptr fpr2(new RegisterAST(ppc32::fpr2));
-  RegisterAST::Ptr fsr0(new RegisterAST(ppc32::fsr0));
-  RegisterAST::Ptr fsr1(new RegisterAST(ppc32::fsr1));
-  RegisterAST::Ptr fsr2(new RegisterAST(ppc32::fsr2));
-  RegisterAST::Ptr fpscr(new RegisterAST(ppc32::fpscw));
-  RegisterAST::Ptr fpscr0(new RegisterAST(ppc32::fpscw0));
-  RegisterAST::Ptr fpscr2(new RegisterAST(ppc32::fpscw2));
-  RegisterAST::Ptr fpscr4(new RegisterAST(ppc32::fpscw4));
-  RegisterAST::Ptr fpscr6(new RegisterAST(ppc32::fpscw6));
-  RegisterAST::Ptr fpscr7(new RegisterAST(ppc32::fpscw7));
-  RegisterAST::Ptr pc(new RegisterAST(ppc32::pc));
-  RegisterAST::Ptr ctr(new RegisterAST(ppc32::ctr));
-  RegisterAST::Ptr lr(new RegisterAST(ppc32::lr));
-  // add.
-  test_results_t retVal = PASSED;
-  
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r0, r8 };
-  tmpWritten = { r9, cr0 };
-#else
-  tmpRead = list_of(r0)(r8);
-  tmpWritten = list_of(r9)(cr0);
-#endif
-  expectedRead.push_back(tmpRead);
+  return ret_val;
+}
 
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // add
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r0, r8 };
-  tmpWritten = { r9 };
-#else
-  tmpRead = list_of(r0)(r8);
-  tmpWritten = list_of(r9);
-#endif
-  expectedRead.push_back(tmpRead);
+test_results_t power_decode_Mutator::run(Dyninst::Architecture arch) {
+  std::vector<Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
 
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // addo
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r0, r8 };
-  tmpWritten = { r9, xer };
-#else
-  tmpRead = list_of(r0)(r8);
-  tmpWritten = list_of(r9)(xer);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-
-  // fadd
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr1, fpr2 };
-  tmpWritten = { fpr0 };
-#else
-  tmpRead = list_of(fpr1)(fpr2);
-  tmpWritten = list_of(fpr0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // fadd.
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr1, fpr2 };
-  tmpWritten = { fpr0, fpscr };
-#else
-  tmpRead = list_of(fpr1)(fpr2);
-  tmpWritten = list_of(fpr0)(fpscr);
-#endif
-
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // addi, r0
-
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpWritten = { r1 };
-#else
-  tmpWritten = list_of(r1);
-#endif
-
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // addi, r1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r1 };
-  tmpWritten = { r1 };
-#else
-  tmpRead = list_of(r1);
-  tmpWritten = list_of(r1);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // fcmpu fpscr7, fpr0, fpr1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr0, fpr1 };
-  tmpWritten = {fpscr7 };
-#else
-  tmpRead = list_of(fpr0)(fpr1);
-  tmpWritten = list_of(fpscr7);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // cmp cr7, r0, r1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r0, r1 };
-  tmpWritten = { cr7 };
-#else
-  tmpRead = list_of(r0)(r1);
-  tmpWritten = list_of(cr7);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // mtcrf cr0, cr2, cr4, cr6, r0
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r0 };
-  tmpWritten = { cr0, cr2, cr4, cr6 };
-#else
-  tmpRead = list_of(r0);
-  tmpWritten = list_of(cr0)(cr2)(cr4)(cr6);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // mtfsf fpscr0, fpscr2, fpscr4, fpscr6, fpr0
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr0 };
-  tmpWritten = { fpscr0, fpscr2, fpscr4, fpscr6 };
-#else
-  tmpRead = list_of(fpr0);
-  tmpWritten = list_of(fpscr0)(fpscr2)(fpscr4)(fpscr6);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // lwz r0, 0(r1)
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r1 };
-  tmpWritten = { r0 };
-#else
-  tmpRead = list_of(r1);
-  tmpWritten = list_of(r0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // lwzu r0, 0(r1)
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r1 };
-  tmpWritten = { r0, r1 };
-#else
-  tmpRead = list_of(r1);
-  tmpWritten = list_of(r0)(r1);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // lwzx r0, r2(r1)
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r1, r2 };
-  tmpWritten = { r0 };
-#else
-  tmpRead = list_of(r1)(r2);
-  tmpWritten = list_of(r0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // lwzux r0, r2(r1)
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r1, r2 };
-  tmpWritten = { r0, r1 };
-#else
-  tmpRead = list_of(r1)(r2);
-  tmpWritten = list_of(r0)(r1);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // rlimi r0, r1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r0 };
-  tmpWritten = { r1 };
-#else
-  tmpRead = list_of(r0);
-  tmpWritten = list_of(r1);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // fpmul fpr0, fpr1, fpr2
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr1, fpr2, fsr1, fsr2 };
-  tmpWritten = { fpr0, fsr0 };
-#else
-  tmpRead = list_of(fpr1)(fpr2)(fsr1)(fsr2);
-  tmpWritten = list_of(fpr0)(fsr0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // fxmul fpr0, fpr1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr1, fpr2, fsr1, fsr2 };
-  tmpWritten = { fpr0, fsr0 };
-#else
-  tmpRead = list_of(fpr1)(fpr2)(fsr1)(fsr2);
-  tmpWritten = list_of(fpr0)(fsr0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-
-  // fxcpmul fpr0, fpr1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr1, fpr2, fsr2 };
-  tmpWritten = { fpr0, fsr0 };
-#else
-  tmpRead = list_of(fpr1)(fpr2)(fsr2);
-  tmpWritten = list_of(fpr0)(fsr0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // fxcsmul fpr0, fpr1
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { fpr2, fsr1, fsr2 };
-  tmpWritten = { fpr0, fsr0 };
-#else
-  tmpRead = list_of(fpr2)(fsr1)(fsr2);
-  tmpWritten = list_of(fpr0)(fsr0);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-
-  // bdnzl cr0, +0x100
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { pc, cr0, ctr };
-  tmpWritten = {pc, ctr, lr };
-#else
-  tmpRead = list_of(pc)(cr0)(ctr);
-  tmpWritten = list_of(pc)(ctr)(lr);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // bdnz cr0, +0x100
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { pc, cr0, ctr };
-  tmpWritten = { pc, ctr };
-#else
-  tmpRead = list_of(pc)(cr0)(ctr);
-  tmpWritten = list_of(pc)(ctr);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-  // lhzux r5, r7, r9
-#if !defined(NO_INITIALIZER_LIST_SUPPORT) && (!defined(os_windows) || _MSC_VER >= 1900)
-  tmpRead = { r7, r9 };
-  tmpWritten = { r5, r7 };
-#else
-  tmpRead = list_of(r7)(r9);
-  tmpWritten = list_of(r5)(r7);
-#endif
-  expectedRead.push_back(tmpRead);
-  expectedWritten.push_back(tmpWritten);
-  tmpRead.clear();
-  tmpWritten.clear();
-
-  decodedInsns.pop_back();
-  while(!decodedInsns.empty())
   {
-      retVal = failure_accumulator(retVal, verify_read_write_sets(decodedInsns.front(), expectedRead.front(),
-                                   expectedWritten.front()));
-      // TEMP
-      if(decodedInsns.size() == 1)
-      {
-          if(!decodedInsns.front().readsMemory())
-          {
-              logerror("**FAILED**: insn %s did not read memory, expected lhzux r5, r7, r9\n",
-                       decodedInsns.front().format().c_str());
-              return FAILED;
-          }
+    InstructionDecoder d(buffer.data(), buffer.size(), arch);
+    for(int idx = 0; idx < num_tests; idx++) {
+      Instruction insn = d.decode();
+      if(!insn.isValid()) {
+        logerror("Failed to decode test %d\n", idx + 1);
+        return FAILED;
       }
-      decodedInsns.pop_front();
-  
-      expectedRead.pop_front();
-      expectedWritten.pop_front();
+      decodedInsns.push_back(insn);
+    }
   }
 
+  const auto is_64 = (arch == Dyninst::Arch_ppc64);
+
+  RegisterAST::Ptr r0(new RegisterAST(is_64 ? ppc64::r0 : ppc32::r0));
+  RegisterAST::Ptr r1(new RegisterAST(is_64 ? ppc64::r1 : ppc32::r1));
+  RegisterAST::Ptr r2(new RegisterAST(is_64 ? ppc64::r2 : ppc32::r2));
+  RegisterAST::Ptr r5(new RegisterAST(is_64 ? ppc64::r5 : ppc32::r5));
+  RegisterAST::Ptr r7(new RegisterAST(is_64 ? ppc64::r7 : ppc32::r7));
+  RegisterAST::Ptr r8(new RegisterAST(is_64 ? ppc64::r8 : ppc32::r8));
+  RegisterAST::Ptr r9(new RegisterAST(is_64 ? ppc64::r9 : ppc32::r9));
+  RegisterAST::Ptr cr0(new RegisterAST(is_64 ? ppc64::cr0 : ppc32::cr0));
+  RegisterAST::Ptr cr2(new RegisterAST(is_64 ? ppc64::cr2 : ppc32::cr2));
+  RegisterAST::Ptr cr4(new RegisterAST(is_64 ? ppc64::cr4 : ppc32::cr4));
+  RegisterAST::Ptr cr6(new RegisterAST(is_64 ? ppc64::cr6 : ppc32::cr6));
+  RegisterAST::Ptr cr7(new RegisterAST(is_64 ? ppc64::cr7 : ppc32::cr7));
+  RegisterAST::Ptr xer(new RegisterAST(is_64 ? ppc64::xer : ppc32::xer));
+  RegisterAST::Ptr fpr0(new RegisterAST(is_64 ? ppc64::fpr0 : ppc32::fpr0));
+  RegisterAST::Ptr fpr1(new RegisterAST(is_64 ? ppc64::fpr1 : ppc32::fpr1));
+  RegisterAST::Ptr fpr2(new RegisterAST(is_64 ? ppc64::fpr2 : ppc32::fpr2));
+  RegisterAST::Ptr fsr0(new RegisterAST(is_64 ? ppc64::fsr0 : ppc32::fsr0));
+  RegisterAST::Ptr fsr1(new RegisterAST(is_64 ? ppc64::fsr1 : ppc32::fsr1));
+  RegisterAST::Ptr fsr2(new RegisterAST(is_64 ? ppc64::fsr2 : ppc32::fsr2));
+  RegisterAST::Ptr fpscw(new RegisterAST(is_64 ? ppc64::fpscw : ppc32::fpscw));
+  RegisterAST::Ptr fpscw0(new RegisterAST(is_64 ? ppc64::fpscw0 : ppc32::fpscw0));
+  RegisterAST::Ptr fpscw2(new RegisterAST(is_64 ? ppc64::fpscw2 : ppc32::fpscw2));
+  RegisterAST::Ptr fpscw4(new RegisterAST(is_64 ? ppc64::fpscw4 : ppc32::fpscw4));
+  RegisterAST::Ptr fpscw6(new RegisterAST(is_64 ? ppc64::fpscw6 : ppc32::fpscw6));
+  RegisterAST::Ptr fpscw7(new RegisterAST(is_64 ? ppc64::fpscw7 : ppc32::fpscw7));
+  RegisterAST::Ptr pc(new RegisterAST(is_64 ? ppc64::pc : ppc32::pc));
+  RegisterAST::Ptr ctr(new RegisterAST(is_64 ? ppc64::ctr : ppc32::ctr));
+  RegisterAST::Ptr lr(new RegisterAST(is_64 ? ppc64::lr : ppc32::lr));
+
+  std::vector<registerSet> expectedRead, expectedWritten;
+
+  //  add. r9, r0, r8
+  expectedRead.push_back({r0, r8});
+  expectedWritten.push_back({r9, cr0});
+
+  //  add r9, r0, r8
+  expectedRead.push_back({r0, r8});
+  expectedWritten.push_back({r9});
+
+  //  addo r9, r0, r8
+  expectedRead.push_back({r0, r8});
+  expectedWritten.push_back({r9, xer});
+
+  //  fadd fpr0, fpr1, fpr2
+  expectedRead.push_back({fpr1, fpr2});
+  expectedWritten.push_back({fpr0});
+
+  //  fadd. fpr0, fpr1, fpr2
+  expectedRead.push_back({fpr1, fpr2});
+  expectedWritten.push_back({fpr0, fpscw});
+
+  //  addi r1, 0, 1
+  expectedRead.push_back({});
+  expectedWritten.push_back({r1});
+
+  //  addi r1, r1, 1
+  expectedRead.push_back({r1});
+  expectedWritten.push_back({r1});
+
+  //  fcmpu fpscw7, fpr0, fpr1
+  expectedRead.push_back({fpr0, fpr1});
+  expectedWritten.push_back({fpscw7});
+
+  //  fcmpu cr7, r0, r1
+  expectedRead.push_back({r0, r1});
+  expectedWritten.push_back({cr7});
+
+  //  mtcrf cr0, cr2, cr4, cr6, r0
+  expectedRead.push_back({r0});
+  expectedWritten.push_back({cr0, cr2, cr4, cr6});
+
+  //  mtfsf fpscw0, fpscw2, fpscw4, fpscw6, fpr0
+  expectedRead.push_back({fpr0});
+  expectedWritten.push_back({fpscw0, fpscw2, fpscw4, fpscw6});
+
+  //  lwz r0, 0(r1)
+  expectedRead.push_back({r1});
+  expectedWritten.push_back({r0});
+
+  //  lwzu r0, 0(r1)
+  expectedRead.push_back({r1});
+  expectedWritten.push_back({r0, r1});
+
+  //  lwzx r0, r2(r1)
+  expectedRead.push_back({r1, r2});
+  expectedWritten.push_back({r0});
+
+  //  lwzux r0, r2(r1)
+  expectedRead.push_back({r1, r2});
+  expectedWritten.push_back({r0, r1});
+
+  //  rlimi r0, r1
+  expectedRead.push_back({r0});
+  expectedWritten.push_back({r1});
+
+  //  fpmul fpr0, fpr1
+  expectedRead.push_back({fpr1, fpr2, fsr1, fsr2});
+  expectedWritten.push_back({fpr0, fsr0});
+
+  //  fxmul fpr0, fpr1, or qvfxmadds
+  expectedRead.push_back({fpr1, fpr2, fsr1, fsr2});
+  expectedWritten.push_back({fpr0, fsr0});
+
+  //  fxcpmul fpr0, fpr1
+  expectedRead.push_back({fpr1, fpr2, fsr2});
+  expectedWritten.push_back({fpr0, fsr0});
+
+  //  fxcsmul fpr0, fpr1, or qvfxxnpmadds
+  expectedRead.push_back({fpr2, fsr1, fsr2});
+  expectedWritten.push_back({fpr0, fsr0});
+
+  //  bdnzl cr0, +0x100
+  expectedRead.push_back({pc, cr0, ctr});
+  expectedWritten.push_back({pc, ctr, lr});
+
+  //  bdnz cr0, +0x100
+  expectedRead.push_back({pc, cr0, ctr});
+  expectedWritten.push_back({pc, ctr});
+
+  //  lhzux r9, r7, r5
+  expectedRead.push_back({r7, r9});
+  expectedWritten.push_back({r5, r7});
+
+  if(expectedRead.size() != expectedWritten.size()) {
+    logerror("FATAL: expectedRead.size() != expectedWritten.size()");
+    return FAILED;
+  }
+
+  if(expectedRead.size() != decodedInsns.size()) {
+    logerror("FATAL: expectedRead.size() != decodedInsns.size()");
+    return FAILED;
+  }
+
+  test_results_t retVal = PASSED;
+  for(auto&& x : boost::combine(decodedInsns, expectedRead, expectedWritten)) {
+    auto insn = x.get<0>();
+    auto read = x.get<1>();
+    auto written = x.get<2>();
+
+    auto status = verify_read_write_sets(insn, read, written);
+    if(status == FAILED) {
+      retVal = FAILED;
+    }
+  }
+
+  {
+    uint32_t lhzux = 0x7ca74a6e; // lhzux r9, r7, r5
+    InstructionDecoder d(&lhzux, 1, arch);
+    Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode for memory test %d\n");
+      return FAILED;
+    }
+    if(!insn.readsMemory()) {
+      logerror("**FAILED**: insn '%s' did not read memory.\n", insn.format().c_str());
+      return FAILED;
+    }
+  }
   return retVal;
 }
-

--- a/src/instruction/test_instruction_bind_eval.C
+++ b/src/instruction/test_instruction_bind_eval.C
@@ -1,178 +1,147 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "Architecture.h"
+#include "Expression.h"
+#include "Instruction.h"
 #include "instruction_comp.h"
+#include "InstructionDecoder.h"
+#include "registers/x86_64_regs.h"
+#include "registers/x86_regs.h"
+#include "Result.h"
 #include "test_lib.h"
 
-#include "Instruction.h"
-#include "InstructionDecoder.h"
-#include "Expression.h"
-#include "Result.h"
-#include "Architecture.h"
-#include <boost/assign/list_of.hpp>
-#include <boost/iterator/indirect_iterator.hpp>
-
-#if defined(arch_x86_64_test)
-# include "registers/x86_64_regs.h"
-  Dyninst::Architecture curArch = Dyninst::Arch_x86_64;
-  using namespace Dyninst::x86_64;
-#elif defined(arch_x86_test)
-# include "registers/x86_regs.h"
-  Dyninst::Architecture curArch = Dyninst::Arch_x86;
-  using namespace Dyninst::x86;
-#endif
+#include <array>
+#include <vector>
 
 using namespace Dyninst;
 using namespace InstructionAPI;
-using namespace boost::assign;
-using namespace boost;
-
-using namespace std;
 
 class test_instruction_bind_eval_Mutator : public InstructionMutator {
+  test_results_t run(Dyninst::Architecture);
+
 public:
-   test_instruction_bind_eval_Mutator() { };
-   virtual test_results_t executeTest();
+  test_instruction_bind_eval_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* test_instruction_bind_eval_factory()
-{
-   return new test_instruction_bind_eval_Mutator();
+extern "C" DLLEXPORT TestMutator* test_instruction_bind_eval_factory() {
+  return new test_instruction_bind_eval_Mutator();
 }
 
+namespace {
+  constexpr auto num_tests = 1;
 
-
-
-
-test_results_t test_instruction_bind_eval_Mutator::executeTest()
-{
-  const unsigned char buffer[] = 
-  {
-    0xFF, 0x94, 0xC1, 0xEF, 0xBE, 0xAD, 0xDE // call [8*EAX + ECX + 0xDEADBEEF]
+  std::array<const uint8_t, 7> buffer = {
+      0xFF, 0x94, 0xC1, 0xEF, 0xBE, 0xAD, 0xDE // call [8*EAX + ECX + 0xDEADBEEF]
   };
-  unsigned int size = 7;
-  unsigned int expectedInsns = 2;
-#if defined(arch_x86_64_test)
-    Architecture curArch = Arch_x86_64;
-    using namespace Dyninst::x86_64;
-#elif defined(arch_x86_test)
-    Architecture curArch = Arch_x86;
-    using namespace Dyninst::x86;
-#else
-    Architecture curArch = Arch_none;
-#endif
-    
-  
-    InstructionDecoder d(buffer, size, curArch);
-    std::vector<Instruction> decodedInsns;
-    Instruction i;
-    do
-    {
-      i = d.decode();
-      decodedInsns.push_back(i);
+}
+
+test_results_t test_instruction_bind_eval_Mutator::executeTest() {
+  auto ret_val = PASSED;
+  {
+    logerror("**** Running x86 ********\n");
+    const auto status = this->run(Dyninst::Arch_x86);
+    if(status == FAILED) {
+      ret_val = FAILED;
     }
-    while(i.isValid());
-    if(decodedInsns.size() != expectedInsns)
-    {
-      logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-      for(std::vector<Instruction>::iterator curInsn = decodedInsns.begin();
-	  curInsn != decodedInsns.end();
-	  ++curInsn)
-      {
-      logerror("\t%s\n", curInsn->format().c_str());
-      }
-      
+  }
+  {
+    logerror("**** Running x86_64 ********\n");
+    const auto status = this->run(Dyninst::Arch_x86_64);
+    if(status == FAILED) {
+      ret_val = FAILED;
+    }
+  }
+  return ret_val;
+}
+
+test_results_t test_instruction_bind_eval_Mutator::run(Dyninst::Architecture arch) {
+  InstructionDecoder d(buffer.data(), buffer.size(), arch);
+
+  std::vector<Instruction> decodedInsns;
+  decodedInsns.reserve(num_tests);
+  for(int idx = 0; idx < num_tests; idx++) {
+    Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode test %d\n", idx + 1);
       return FAILED;
     }
-    if(decodedInsns.back().isValid())
-    {
-      logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
+    decodedInsns.push_back(insn);
+  }
+
+  const auto is_64 = (arch == Dyninst::Arch_x86_64);
+  RegisterAST ax(is_64 ? x86_64::rax : x86::eax);
+  RegisterAST cx(is_64 ? x86_64::rcx : x86::ecx);
+
+  for(auto&& insn : decodedInsns) {
+    Expression::Ptr theCFT = insn.getControlFlowTarget();
+    if(!theCFT) {
+      logerror("FAILED: no CFT found for '%s'\n", insn.format().c_str());
+      return FAILED;
+    }
+    if(verifyCFT(theCFT, false, 0x1000, u32) == FAILED) {
       return FAILED;
     }
 
-  Expression::Ptr theCFT = decodedInsns[0].getControlFlowTarget();
-  if(!theCFT) {
-    logerror("FAILED: instruction %s decoded from call [8*EAX + ECX + 0xDEADBEEF], no CFT found\n",
-             decodedInsns[0].format().c_str());
-    return FAILED;
+    if(!theCFT->bind(&ax, Result(u32, 3))) {
+      logerror("FAILED: bind of EAX failed (insn %s)\n", insn.format().c_str());
+      return FAILED;
+    }
+    if(verifyCFT(theCFT, false, 0x1000, u32) == FAILED) {
+      return FAILED;
+    }
+    if(!theCFT->bind(&cx, Result(u32, 5))) {
+      logerror("FAILED: bind of ECX failed\n");
+      return FAILED;
+    }
+    if(verifyCFT(theCFT, false, 0x1000, u32) == FAILED) {
+      return FAILED;
+    }
+    vector<Expression::Ptr> tmp;
+    theCFT->getChildren(tmp);
+    if(tmp.size() != 1) {
+      logerror("FAILED: expected dereference with one child, got %d children\n", tmp.size());
+      return FAILED;
+    }
+    Expression::Ptr memRef = tmp[0];
+    if(!memRef) {
+      logerror("FAILED: memRef was not an expression\n");
+      return FAILED;
+    }
+    using res_t = typename Result_type2type<u32>::type;
+    auto expected_value = static_cast<res_t>(0xDEADBEEF + (0x03 * 0x08 + 0x05));
+    if(verifyCFT(memRef, true, expected_value, u32) == FAILED) {
+      return FAILED;
+    }
   }
-  if(verifyCFT(theCFT, false, 0x1000, u32) == FAILED)
-  {
-    return FAILED;
-  }
-  
-#if defined(arch_x86_64_test)
-  RegisterAST* r_eax = new RegisterAST(x86_64::eax);
-  RegisterAST* r_ecx = new RegisterAST(x86_64::ecx);
-#elif defined(arch_x86_test)
-  RegisterAST* r_eax = new RegisterAST(x86::eax);
-  RegisterAST* r_ecx = new RegisterAST(x86::ecx);
-#else
-#error "Test_instruction_bind_eval should be x86 only!"
-#endif
-    
-  Result three(u32, 3);
-  Result five(u32, 5);
-  
-  if(!theCFT->bind(r_eax, three)) {
-      logerror("FAILED: bind of EAX failed (insn %s)\n", decodedInsns[0].format().c_str());
-    return FAILED;
-  }
-  if(verifyCFT(theCFT, false, 0x1000, u32) == FAILED)
-  {
-    return FAILED;
-  }
-  if(!theCFT->bind(r_ecx, five)) {
-    logerror("FAILED: bind of ECX failed\n");
-    return FAILED;
-  }
-  if(verifyCFT(theCFT, false, 0x1000, u32) == FAILED)
-  {
-    return FAILED;
-  }
-  vector<Expression::Ptr> tmp;
-  theCFT->getChildren(tmp);
-  if(tmp.size() != 1)
-  {
-    logerror("FAILED: expected dereference with one child, got %d children\n", tmp.size());
-    return FAILED;
-  }
-  Expression::Ptr memRef = tmp[0];
-  if(!memRef) {
-    logerror("FAILED: memRef was not an expression\n");
-    return FAILED;
-  }
-  if(verifyCFT(memRef, true, 0xDEADBEEF + (0x03 * 0x08 + 0x05), u32) == FAILED) {
-    return FAILED;
-  }
-
   return PASSED;
 }
-

--- a/src/instruction/test_instruction_farcall.C
+++ b/src/instruction/test_instruction_farcall.C
@@ -1,120 +1,68 @@
 /*
  * See the dyninst/COPYRIGHT file for copyright information.
- * 
+ *
  * We provide the Paradyn Tools (below described as "Paradyn")
  * on an AS IS basis, and do not warrant its validity or performance.
  * We reserve the right to update, modify, or discontinue this
  * software at any time.  We shall have no obligation to supply such
  * updates or modifications or any other form of support to you.
- * 
+ *
  * By your use of Paradyn, you understand and agree that we (or any
  * other person or entity with proprietary rights in Paradyn) are
  * under no obligation to provide either maintenance services,
  * update services, notices of latent defects, or correction of
  * defects for Paradyn.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "instruction_comp.h"
-#include "test_lib.h"
-
 #include "Instruction.h"
+#include "instruction_comp.h"
 #include "InstructionDecoder.h"
-
-#include <boost/assign.hpp>
-#include <boost/iterator/indirect_iterator.hpp>
+#include "test_lib.h"
 
 using namespace Dyninst;
 using namespace InstructionAPI;
-using namespace boost;
-using namespace std;
 
 class test_instruction_farcall_Mutator : public InstructionMutator {
 public:
-   test_instruction_farcall_Mutator() { };
-   virtual test_results_t executeTest();
+  test_instruction_farcall_Mutator() {}
+
+  virtual test_results_t executeTest() override;
 };
 
-extern "C" DLLEXPORT TestMutator* test_instruction_farcall_factory()
-{
-   return new test_instruction_farcall_Mutator();
+extern "C" DLLEXPORT TestMutator* test_instruction_farcall_factory() {
+  return new test_instruction_farcall_Mutator();
 }
 
+test_results_t test_instruction_farcall_Mutator::executeTest() {
+  constexpr auto num_tests = 1;
 
-test_results_t test_instruction_farcall_Mutator::executeTest()
-{
-  const unsigned char buffer[] = 
-  {
-    0x9A, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF, 0xFE // CALL 0504030201, with FF/FE as fenceposts
+  // This form is only valid on 32-bit x86
+  std::array<const uint8_t, 9> buffer = {
+      0x9A, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF, 0xFE // CALL 0504030201, with FF/FE as fenceposts
   };
-  unsigned int size = 7;
-  unsigned int expectedInsns = 2;
 
-#if defined(arch_x86_64_test)
-    Architecture curArch = Arch_x86_64;
-#elif defined(arch_x86_test)
-    Architecture curArch = Arch_x86;
-#else
-    Architecture curArch = Arch_none;
-#endif
-    
-  
-    InstructionDecoder d(buffer, size, curArch);
-    std::vector<Instruction> decodedInsns;
-    Instruction i;
-    do
-    {
-      i = d.decode();
-      decodedInsns.push_back(i);
+  InstructionDecoder d(buffer.data(), buffer.size(), Dyninst::Arch_x86);
+
+  for(int idx = 0; idx < num_tests; idx++) {
+    Instruction insn = d.decode();
+    if(!insn.isValid()) {
+      logerror("Failed to decode test %d\n", idx + 1);
+      return FAILED;
     }
-    while(i.isValid());
-#if defined(arch_x86_64_test)
-  if(decodedInsns.empty() || decodedInsns[0].isLegalInsn())
-  {
-    logerror("FAILED: %s\n", decodedInsns.empty() ? "no instructions decoded" : "first instruction was valid");
-    return FAILED;
-  }
-  else
-  {
-    logerror("PASSED: far call invalid on AMD64\n");
-    return PASSED;
-  }
-#else
-  if(decodedInsns.size() != expectedInsns) // six valid, one invalid
-  {
-    logerror("FAILED: Expected %d instructions, decoded %d\n", expectedInsns, decodedInsns.size());
-    for(std::vector<Instruction>::iterator curInsn = decodedInsns.begin();
-	curInsn != decodedInsns.end();
-	++curInsn)
-    {
-      logerror("\t%s\t", (*curInsn).format().c_str());
-      for(unsigned j = 0; j < (*curInsn).size(); ++j)
-      {
-	logerror("%x ", (*curInsn).rawByte(j));
-      }
-      logerror("\n");
-    }
-    
-    return FAILED;
-  }
-  if(decodedInsns.size() > 0 && decodedInsns.back().isValid())
-  {
-    logerror("FAILED: Expected instructions to end with an invalid instruction, but they didn't");
-    return FAILED;
   }
   return PASSED;
-#endif
 }


### PR DESCRIPTION
Several of these tests suffered the same problem as #242. Others had bugs just waiting to crash. And some, particularly fucompp, were just wrong and never did anything useful. This also extends the number of cases in a couple of tests by more than a factor of 20.