### PR TITLE
Separate usage of aarch64 pstate and nzcv flag registers

### DIFF
--- a/src/instruction/aarch64_decode.C
+++ b/src/instruction/aarch64_decode.C
@@ -445,7 +445,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   RegisterAST::Ptr sp = create(aarch64::sp);
   RegisterAST::Ptr wsp = create(aarch64::wsp);
   RegisterAST::Ptr pc = create(aarch64::pc);
-  RegisterAST::Ptr pstate = create(aarch64::pstate);
+  RegisterAST::Ptr nzcv = create(aarch64::nzcv);
 
   RegisterAST::Ptr pmceid0_el0 = create(aarch64::pmceid0_el0);
   RegisterAST::Ptr pmevcntr2_el0 = create(aarch64::pmevcntr2_el0);
@@ -476,7 +476,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // ADDS W0, W5, W8, LSL #5
   expectedRead.push_back({w8,w5});
-  expectedWritten.push_back({w0,pstate});
+  expectedWritten.push_back({w0,nzcv});
 
   // ADD W5, W10, W15
   expectedRead.push_back({x15, w10});
@@ -488,7 +488,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // SUBS X2, X2, X2, SXTW #4
   expectedRead.push_back({x2,x2});
-  expectedWritten.push_back({x2,pstate});
+  expectedWritten.push_back({x2,nzcv});
 
   // ADC W5, W22, W25
   expectedRead.push_back({w25, w22});
@@ -499,35 +499,35 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({x0});
 
   // CCMN W7, #30, #11, 5
-  expectedRead.push_back({w7,pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({w7,nzcv});
+  expectedWritten.push_back({nzcv});
 
   // CCMP X20, #8, #0, 15
-  expectedRead.push_back({x20,pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({x20,nzcv});
+  expectedWritten.push_back({nzcv});
 
   // CCMN W5, W10, #7, 1
-  expectedRead.push_back({w10,w5,pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({w10,w5,nzcv});
+  expectedWritten.push_back({nzcv});
 
   // CCMP X2, X4, #4, 10
-  expectedRead.push_back({x2,x4,pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({x2,x4,nzcv});
+  expectedWritten.push_back({nzcv});
 
   // CSEL W5, W10, W15, 1
-  expectedRead.push_back({w15,w10,pstate});
+  expectedRead.push_back({w15,w10,nzcv});
   expectedWritten.push_back({w5});
 
   // CSINC X0, X2, X4, 5
-  expectedRead.push_back({x2,x4,pstate});
+  expectedRead.push_back({x2,x4,nzcv});
   expectedWritten.push_back({x0});
 
   // CSINV X20, X21, X22, 7
-  expectedRead.push_back({x21,x22,pstate});
+  expectedRead.push_back({x21,x22,nzcv});
   expectedWritten.push_back({x20});
 
   // CSNEG W1, W5, W9, 10
-  expectedRead.push_back({w5,w10,pstate});
+  expectedRead.push_back({w5,w10,nzcv});
   expectedWritten.push_back({w1});
 
   // RBIT W1, W2
@@ -604,7 +604,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // BICS X1, X1, X1, ROR #8
   expectedRead.push_back({x1, x1});
-  expectedWritten.push_back({x1, pstate});
+  expectedWritten.push_back({x1, nzcv});
 
   // ADD W0, WSP, #11
   expectedRead.push_back({wsp});
@@ -612,7 +612,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // ADDS W5, W10, #0, LSL #12
   expectedRead.push_back({w10});
-  expectedWritten.push_back({w5, pstate});
+  expectedWritten.push_back({w5, nzcv});
 
   // SUB SP, X10, #12
   expectedRead.push_back({x10});
@@ -652,7 +652,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // ANDS W5, W10, #9
   expectedRead.push_back({w10});
-  expectedWritten.push_back({w5, pstate});
+  expectedWritten.push_back({w5, nzcv});
 
   // MOVN W4, #23, LSL #1
   expectedRead.push_back({});
@@ -687,11 +687,11 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({pc});
 
   // B.NE #
-  expectedRead.push_back({pc, pstate});
+  expectedRead.push_back({pc, nzcv});
   expectedWritten.push_back({pc});
 
   // B.GT #63
-  expectedRead.push_back({pc, pstate});
+  expectedRead.push_back({pc, nzcv});
   expectedWritten.push_back({pc});
 
   // TBZ W4, #30, #
@@ -728,30 +728,30 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // FCMP S0, S31
   expectedRead.push_back({s31, s0});
-  expectedWritten.push_back({pstate});
+  expectedWritten.push_back({nzcv});
 
   // FCMP D16, #0.0
   expectedRead.push_back({s8});
-  expectedWritten.push_back({pstate});
+  expectedWritten.push_back({nzcv});
 
   // FCMP D31, D32
   expectedRead.push_back({d31, d30});
-  expectedWritten.push_back({pstate});
+  expectedWritten.push_back({nzcv});
 
   // FCCMP S20, S31, #8, 10
-  expectedRead.push_back({s31, s20, pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({s31, s20, nzcv});
+  expectedWritten.push_back({nzcv});
 
   // FCCMP D1, D2, #5, 0
-  expectedRead.push_back({d2, d1, pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({d2, d1, nzcv});
+  expectedWritten.push_back({nzcv});
 
   // FCCMPE D10, D1,, #9, 5
-  expectedRead.push_back({d11, d10, pstate});
-  expectedWritten.push_back({pstate});
+  expectedRead.push_back({d11, d10, nzcv});
+  expectedWritten.push_back({nzcv});
 
   // FCSEL S1, S, S3, 4
-  expectedRead.push_back({s3, s2, pstate});
+  expectedRead.push_back({s3, s2, nzcv});
   expectedWritten.push_back({s1});
 
   // FMOV S5, S10
@@ -875,19 +875,19 @@ test_results_t aarch64_decode_Mutator::executeTest() {
   expectedWritten.push_back({s1});
 
   // SVC #32768
-  expectedRead.push_back({pstate});
+  expectedRead.push_back({nzcv});
   expectedWritten.push_back({});
 
   // SMC #0
-  expectedRead.push_back({pstate});
+  expectedRead.push_back({nzcv});
   expectedWritten.push_back({});
 
   // HLT #30
-  expectedRead.push_back({pstate});
+  expectedRead.push_back({nzcv});
   expectedWritten.push_back({});
 
   // DCPS2 #2
-  expectedRead.push_back({pstate});
+  expectedRead.push_back({nzcv});
   expectedWritten.push_back({});
 
   // CLREX
@@ -908,7 +908,7 @@ test_results_t aarch64_decode_Mutator::executeTest() {
 
   // MSR 30, #5
   expectedRead.push_back({});
-  expectedWritten.push_back({pstate});
+  expectedWritten.push_back({nzcv});
 
   // SYS #1, #2, #3, #4, X0
   expectedRead.push_back({x0});

--- a/src/instruction/aarch64_decode_ldst.C
+++ b/src/instruction/aarch64_decode_ldst.C
@@ -500,7 +500,7 @@ test_results_t aarch64_decode_ldst_Mutator::executeTest() {
   RegisterAST::Ptr sp = create(aarch64::sp);
   RegisterAST::Ptr wsp = create(aarch64::wsp);
   RegisterAST::Ptr pc = create(aarch64::pc);
-  RegisterAST::Ptr pstate = create(aarch64::pstate);
+  RegisterAST::Ptr nzcv = create(aarch64::nzcv);
 
   std::vector<registerSet> expectedRead, expectedWritten;
 
@@ -937,15 +937,15 @@ test_results_t aarch64_decode_ldst_Mutator::executeTest() {
   expectedWritten.push_back({x1});
 
   // csinc x0, x1, x2, eq
-  expectedRead.push_back({x1, x2, pstate});
+  expectedRead.push_back({x1, x2, nzcv});
   expectedWritten.push_back({x0});
 
   // csinv x0, x1, x2, eq
-  expectedRead.push_back({x1, x2, pstate});
+  expectedRead.push_back({x1, x2, nzcv});
   expectedWritten.push_back({x0});
 
   // csneg x0, x1, x2, eq
-  expectedRead.push_back({x1, x2, pstate});
+  expectedRead.push_back({x1, x2, nzcv});
   expectedWritten.push_back({x0});
 
   // ubfiz x0, x1, #1, #1


### PR DESCRIPTION
This is the same as #246.