### PR TITLE
Update, fix, extend PowerPC CFT and decode tests

### DIFF
--- a/src/instruction/instruction_comp.C
+++ b/src/instruction/instruction_comp.C
@@ -280,7 +280,7 @@ test_results_t InstructionMutator::verify_read_write_sets(Instruction i, const r
         }
         return FAILED;
     }
-    logerror("PASSED: Instruction %s had read, write sets as expected\n", i.format().c_str());
+    logstatus("PASSED: Instruction %s had read, write sets as expected\n", i.format().c_str());
     return PASSED;
 }
 

--- a/src/instruction/power_cft.C
+++ b/src/instruction/power_cft.C
@@ -321,7 +321,7 @@ namespace {
         {},
         test_cft{lr_value, {!is_call, is_conditional, is_indirect, !is_fallthrough}},
         {},
-        test_cft{pc_value + 4, {!is_call, !is_conditional, is_indirect, is_fallthrough}},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
       },
       { // bdnzfl gt, 0x100
         0x40010101, !is_branch, !is_return,

--- a/src/instruction/power_cft.C
+++ b/src/instruction/power_cft.C
@@ -32,20 +32,19 @@
 #include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
-#include "registers/ppc32_regs.h"
 #include "registers/ppc64_regs.h"
 #include "test_lib.h"
 
-#include <boost/range/combine.hpp>
-#include <tuple>
+#include <boost/optional.hpp>
+#include <boost/none_t.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <vector>
 
 using namespace Dyninst;
 using namespace InstructionAPI;
 
 class power_cft_Mutator : public InstructionMutator {
-  test_results_t run(Dyninst::Architecture);
-
 public:
   power_cft_Mutator() {}
 
@@ -57,196 +56,327 @@ extern "C" DLLEXPORT TestMutator* power_cft_factory() {
 }
 
 struct cftExpected {
-  bool defined;
-  unsigned int expected;
-  bool call;
-  bool conditional;
-  bool indirect;
-  bool fallthrough;
+  bool is_call;
+  bool is_conditional;
+  bool is_indirect;
+  bool is_fallthrough;
 };
 
 test_results_t verifyTargetType(const Instruction::CFT& actual, const cftExpected& expected) {
-  if(actual.isCall != expected.call) {
-    logerror("FAILED: expected call = %d, actual = %d\n", expected.call, actual.isCall);
+  if(actual.isCall != expected.is_call) {
+    logerror("FAILED: expected call = %d, actual = %d\n", expected.is_call, actual.isCall);
     return FAILED;
   }
-  if(actual.isIndirect != expected.indirect) {
-    logerror("FAILED: expected indirect = %d, actual = %d\n", expected.indirect, actual.isIndirect);
+  if(actual.isIndirect != expected.is_indirect) {
+    logerror("FAILED: expected indirect = %d, actual = %d\n", expected.is_indirect, actual.isIndirect);
     return FAILED;
   }
-  if(actual.isConditional != expected.conditional) {
-    logerror("FAILED: expected conditional = %d, actual = %d\n", expected.conditional, actual.isConditional);
+  if(actual.isConditional != expected.is_conditional) {
+    logerror("FAILED: expected conditional = %d, actual = %d\n", expected.is_conditional, actual.isConditional);
     return FAILED;
   }
-  if(actual.isFallthrough != expected.fallthrough) {
-    logerror("FAILED: expected fallthrough = %d, actual = %d\n", expected.fallthrough, actual.isFallthrough);
+  if(actual.isFallthrough != expected.is_fallthrough) {
+    logerror("FAILED: expected fallthrough = %d, actual = %d\n", expected.is_fallthrough, actual.isFallthrough);
     return FAILED;
   }
+
   return PASSED;
 }
 
 namespace {
+  struct test_cft {
+    uint32_t value;
+    cftExpected cft;
+  };
   struct test_insn {
     const uint32_t opcode;
-    std::vector<cftExpected> expected_targets;
+    bool is_branch;
+    bool is_return;
+    boost::optional<test_cft> pc;   // program counter
+    boost::optional<test_cft> ctr;  // count register
+    boost::optional<test_cft> lr;   // link register
+    boost::optional<test_cft> abs;  // absolute value (AA=1 instructions)
+    boost::optional<test_cft> ft;   // fallthrough target
   };
 
-  // clang-format off
-  auto tests = std::vector<test_insn> {
-    {
-      //  b +16
-      {0x48000010},
-      {
-        {true, 0x410, false, false, false, false},
-      }
-    },
-    {
-      //  b +32
-      {0x42f00020},
-      {
-        {true, 0x420, false, false, false, false},
-      }
-    },
-    {
-      //  bctr
-      {0x4ef00420},
-      {
-        {true, 44, false, false, true, false},
-      }
-    },
-    {
-      //  b 32
-      {0x42f00022},
-      {
-        {true, 0x20, false, false, false, false},
-      }
-    },
-    {
-      //  b -32
-      {0x42f0ffd0},
-      {
-        {true, 0x3d0, false, false, false, false},
-      }
-    },
-    {
-      //  blr
-      {0x4ef00020},
-      {
-        {true, 0x200, false, false, true, false},
-      }
-    },
-    {
-      //  bdnzl cr0
-      {0x40010101},
-      {
-        {true, 0x500, true, true, false, false},
-        {true, 0x404, false, false, false, true},
-      }
-    },
-    {
-      //  bdnz cr0
-      {0x40010100},
-      {
-        {true, 0x500, false, true, false, false},
-        {true, 0x404, false, false, false, true},
-      }
-    },
-    {
-      //  bctrl
-      {0x4ef00421},
-      {
-        {true, 44, true, false, true, false},
-      }
-    },
-    {
-      //  bnslr+
-      {0x4ca30020},
-      {
-        {true, 0x200, false, true, true, false},
-        {true, 0x404, false, false, false, true},
-      }
-    }
-  };
-  // clang-format on
+  constexpr auto pc_value = uint32_t{0x400};
+  constexpr auto ctr_value = uint32_t{44};
+  constexpr auto lr_value = uint32_t{0x200};
+
+  auto pc = boost::make_shared<RegisterAST>(ppc64::pc);
+  auto ctr = boost::make_shared<RegisterAST>(ppc64::ctr);
+  auto lr = boost::make_shared<RegisterAST>(ppc64::lr);
+
+  std::vector<test_insn> make_tests();
 }
 
 test_results_t power_cft_Mutator::executeTest() {
-  auto ret_val = PASSED;
-  {
-    logerror("**** Running ppc32 ********\n");
-    const auto status = this->run(Dyninst::Arch_ppc32);
-    if(status == FAILED) {
-      ret_val = FAILED;
-    }
-  }
-  {
-    logerror("**** Running ppc64 ********\n");
-    const auto status = this->run(Dyninst::Arch_ppc64);
-    if(status == FAILED) {
-      ret_val = FAILED;
-    }
-  }
-  return ret_val;
-}
-
-test_results_t power_cft_Mutator::run(Dyninst::Architecture arch) {
-  const auto is_64 = (arch == Dyninst::Arch_ppc64);
-
-  RegisterAST::Ptr pc(new RegisterAST(is_64 ? ppc64::pc : ppc32::pc));
-  RegisterAST::Ptr ctr(new RegisterAST(is_64 ? ppc64::ctr : ppc32::ctr));
-  RegisterAST::Ptr lr(new RegisterAST(is_64 ? ppc64::lr : ppc32::lr));
-
   test_results_t retVal = PASSED;
   auto test_id = 0;
 
-  for(auto&& t : tests) {
+  for(auto const& t : make_tests()) {
     test_id++;
 
-    InstructionDecoder d(&(t.opcode), 4, arch);
+    InstructionDecoder d(&(t.opcode), 4, Dyninst::Arch_ppc64);
     Instruction insn = d.decode();
+
     if(!insn.isValid()) {
       logerror("Failed to decode test %d\n", test_id);
       retVal = FAILED;
       continue;
     }
 
-    const auto num_cft = std::distance(insn.cft_begin(), insn.cft_end());
-    const auto num_expected_cft = t.expected_targets.size();
+    logstatus("\ntest %d: '%s'\n", test_id, insn.format().c_str());
 
-    if(num_cft != num_expected_cft) {
-      logerror("FAILED: Number of targets mismatched for test %d '%s'. Found %u, expected %u\n", test_id,
-               insn.format().c_str(), num_cft, num_expected_cft);
+    auto all_cfts = boost::make_iterator_range(insn.cft_begin(), insn.cft_end());
+    const auto num_cft = std::distance(insn.cft_begin(), insn.cft_end());
+
+    if(!num_cft) {
+      logerror("FAILED: No control flow targets found\n");
       retVal = FAILED;
       continue;
     }
 
-    auto cft_all = boost::make_iterator_range(insn.cft_begin(), insn.cft_end());
-    for(auto&& cft : boost::combine(cft_all, t.expected_targets)) {
-      Instruction::CFT cft_cur = cft.get<0>();
-      auto target = cft_cur.target;
+    constexpr auto result_val_t = u64;
 
-      if(!target) {
-        logerror("FAILED: No target for '%s'\n", insn.format().c_str());
-        retVal = FAILED;
-        continue;
+    auto bind_val = [](Instruction::CFT const& cur_cft, Expression::Ptr target, uint32_t value) {
+      cur_cft.target->bind(target.get(), Result(result_val_t, value));
+    };
+
+    auto check_cft = [this](Instruction::CFT const& cur_cft, boost::optional<test_cft> test_reg) {
+      if(!test_reg.has_value()) {
+        logerror("FAILED: test does not use register, but should\n");
+        return FAILED;
       }
 
-      target->bind(pc.get(), Result(u32, 0x400));
-      target->bind(ctr.get(), Result(u32, 44));
-      target->bind(lr.get(), Result(u32, 0x200));
-
-      cftExpected cft_expected = cft.get<1>();
-
-      auto status = verifyCFT(target, cft_expected.defined, cft_expected.expected, u32);
+      constexpr auto defined = true;
+      auto status = verifyCFT(cur_cft.target, defined, test_reg->value, result_val_t);
       if(status == FAILED) {
-        retVal = FAILED;
+        return FAILED;
       }
 
-      status = verifyTargetType(cft_cur, cft_expected);
+      status = verifyTargetType(cur_cft, test_reg->cft);
       if(status == FAILED) {
-        retVal = FAILED;
+        return FAILED;
+      }
+
+      return PASSED;
+    };
+
+    int const num_targets_expected = [&t]() {
+      int n=0;
+      if(t.pc) n++;
+      if(t.ctr) n++;
+      if(t.lr) n++;
+      if(t.abs) n++;
+      if(t.ft) n++;
+      return n;
+    }();
+
+    int num_targets_seen = 0;
+    bool abs_was_used = false;
+    for(auto const& cur_cft : all_cfts) {
+      logstatus("Target %d: '%s'\n", num_targets_seen+1, cur_cft.target->format(Dyninst::Arch_ppc64).c_str());
+
+      if(t.abs && !abs_was_used) {
+        logstatus("Checking absolute address\n");
+        num_targets_seen++;
+        bind_val(cur_cft, cur_cft.target, t.abs->value);
+        if(check_cft(cur_cft, t.abs) == FAILED) {
+          retVal = FAILED;
+        }
+        abs_was_used = true;
+      }
+      if(cur_cft.target->isUsed(pc)) {
+        logstatus("Checking PC\n");
+        num_targets_seen++;
+        bind_val(cur_cft, pc, pc_value);
+        if(check_cft(cur_cft, t.pc) == FAILED) {
+          logstatus("  Trying fallthrough...\n");
+          if(!t.ft || (check_cft(cur_cft, t.ft) == FAILED)) {
+            retVal = FAILED;
+          }
+        }
+      }
+      if(cur_cft.target->isUsed(ctr)) {
+        logstatus("Checking count register\n");
+        num_targets_seen++;
+        bind_val(cur_cft, ctr, ctr_value);
+        if(check_cft(cur_cft, t.ctr) == FAILED) {
+          retVal = FAILED;
+        }
+      }
+      if(cur_cft.target->isUsed(lr)) {
+        logstatus("Checking link register\n");
+        num_targets_seen++;
+        bind_val(cur_cft, lr, lr_value);
+        if(check_cft(cur_cft, t.lr) == FAILED) {
+          retVal = FAILED;
+        }
       }
     }
+    if(num_targets_seen != num_targets_expected) {
+      logerror("FAILED: instruction has too %s targets; expected %d, found %d\n",
+        (num_targets_seen < num_targets_expected) ? "few" : "many",
+        num_targets_expected,
+        num_targets_seen
+      );
+      retVal = FAILED;
+    }
+    if(insn.isBranch() != t.is_branch) {
+      logerror("FAILED: instruction should %s be a branch\n",
+               (t.is_branch) ? "" : "not");
+      retVal = FAILED;
+    }
+    if(insn.isReturn() != t.is_return) {
+      logerror("FAILED: instruction should %s be a return\n",
+              (t.is_return) ? "" : "not");
+      retVal = FAILED;
+    }
   }
+
   return retVal;
+}
+
+namespace {
+
+  constexpr auto is_call = true;
+  constexpr auto is_conditional = true;
+  constexpr auto is_indirect = true;
+  constexpr auto is_fallthrough = true;
+  constexpr auto is_branch = true;
+  constexpr auto is_return = true;
+
+  // clang-format off
+  std::vector<test_insn> make_tests() {
+    return {
+      /*
+       *  --- Branch I-form ---
+       */
+      { //  b +16
+        0x48000010, is_branch, !is_return,
+        test_cft{pc_value + 16, {!is_call, !is_conditional, !is_indirect, !is_fallthrough}}
+      },
+      { //  ba -48
+        0x4bffffd2, is_branch, !is_return
+      },
+      { //  bl 0x100
+        0x48000101, !is_branch, !is_return,
+        test_cft{pc_value + 0x100, {is_call, !is_conditional, !is_indirect, !is_fallthrough}}
+      },
+      { //  bla 0x100
+        0x48000103, !is_branch, !is_return
+      },
+
+      /*
+       *  --- Branch Conditional B-form ---
+       */
+      { //  bc +32
+        0x42f00020, is_branch, !is_return,
+        test_cft{pc_value + 32, {!is_call, is_conditional, !is_indirect, !is_fallthrough}},
+        {},
+        {},
+        {},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
+      },
+      { //  bca 32
+        0x42f00022, is_branch, !is_return,
+        {},
+        {},
+        {},
+        test_cft{32, {!is_call, is_conditional, !is_indirect, !is_fallthrough}},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+      },
+      { //  bcl +32  (subroutine call to relative address)
+        0x42f00021, !is_branch, !is_return,
+        test_cft{pc_value + 32, {is_call, is_conditional, !is_indirect, !is_fallthrough}},
+        {},
+        {},
+        {},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+      },
+      { //  bcla 32  (subroutine call to immediate target)
+        0x42f00023, !is_branch, !is_return,
+        {},
+        {},
+        {},
+        test_cft{pc_value + 32, {is_call, is_conditional, !is_indirect, !is_fallthrough}},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
+      },
+
+      /*
+       *  --- Branch Conditional to Link Register XL-form ---
+       *
+       *  There are a large number of uses for this instruction.
+       */
+      { //  bclr with BH=0 (subroutine return)
+        0x4e800020, !is_branch, is_return,
+        {},
+        {},
+        test_cft{lr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      },
+      { // bclrl  (LK=1)
+        0x4e800021, is_branch, !is_return,
+        {},
+        {},
+        test_cft{lr_value, {!is_call, is_conditional, is_indirect, !is_fallthrough}},
+        {},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, is_indirect, is_fallthrough}},
+      },
+      { // bdnzfl gt, 0x100
+        0x40010101, !is_branch, !is_return,
+        test_cft{pc_value + 0x100, {is_call, is_conditional, !is_indirect, !is_fallthrough}},
+        {},
+        {},
+        {},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}}
+      },
+      { //  bdnzf gt, 0x100   (bdnz cr0)
+        0x40010100, is_branch, !is_return,
+        test_cft{pc_value + 0x100, {!is_call, is_conditional, !is_indirect, !is_fallthrough}},
+        {},
+        {},
+        {},
+        test_cft{pc_value + 4, {!is_call, !is_conditional, !is_indirect, is_fallthrough}},
+      },
+      { //  bnslr
+        0x4ca30020, !is_branch, is_return,
+        {},
+        {},
+        test_cft{lr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      },
+
+      /*
+       *  --- Branch Conditional to Count Register XL-form ---
+       */
+      { //  bctr  (LK=0)
+        0x4e800420, is_branch, !is_return,
+        {},
+        test_cft{ctr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      },
+      { //  bctrl  (LK=1)
+        0x4e800421, !is_branch, !is_return,
+        {},
+        test_cft{ctr_value, {is_call, !is_conditional, is_indirect, !is_fallthrough}},
+      },
+      { //  bcctr 0x17, 4*cr4+lt, 0
+        0x4ef00420, is_branch, !is_return,
+        {},
+        test_cft{ctr_value, {!is_call, !is_conditional, is_indirect, !is_fallthrough}}
+      },
+
+      /*
+       *  --- Branch Conditional to Branch Target Address Register XL-form ---
+       *
+       *  Dyninst can't decode these.
+       */
+//      { // bctar   (LK=0)
+//        0x4e800460
+//      },
+//      { // bctarl  (LK=1)
+//        0x4e800461
+//      },
+    };
+  // clang-format on
+  }
 }


### PR DESCRIPTION
I have no idea how or why, but Dyninst incorrectly decodes the bclr instruction properties in 32-bit mode so the power_cft test now only checks ppc64le.

Requires https://github.com/dyninst/dyninst/pull/1929