### PR TITLE
Remove use of common/util.h

### DIFF
--- a/src/dyninst/ParseThat.C
+++ b/src/dyninst/ParseThat.C
@@ -28,7 +28,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "ParseThat.h"
-#include "util.h"
 #include "dyninst_comp.h"
 #include "test_lib.h"
 #include <sys/types.h>

--- a/src/dyninst/ParseThat.h
+++ b/src/dyninst/ParseThat.h
@@ -34,7 +34,7 @@
 #include <vector>
 #include "test_lib.h"
 //#include "dyninst_comp.h"
-#include "util.h"
+
 //  A (hopefully simple) c++ class interface for issuing parseThat commands
 //  inside the testsuite
 

--- a/src/dyninst/test_lib_mutateeStart.C
+++ b/src/dyninst/test_lib_mutateeStart.C
@@ -37,7 +37,6 @@
 
 #include "dyninst_comp.h"
 #include "test_lib.h"
-#include "util.h"
 #include "ResumeLog.h"
 #include "MutateeStart.h"
 #include <stdlib.h>

--- a/src/test_lib.h
+++ b/src/test_lib.h
@@ -38,13 +38,13 @@
 #include "TestData.h"
 #include "test_info_new.h"
 #include "test_lib_dll.h"
-#include "util.h"
 #include <errno.h>
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "dyntypes.h"
 
 #if !defined(P_sleep)
 #if defined(os_windows_test)


### PR DESCRIPTION
I'm working on a bunch of updates for that file, and they aren't needed in the test suite.