### PR TITLE
Use CMake CTest module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,3 +336,5 @@ if(DYNINST_ENABLE_32BIT_TESTS)
 endif()
 
 include(${DYNINST_PLATFORM}/cmake-mutatees.txt)
+
+include(CTest)


### PR DESCRIPTION
This is needed to upload ctest results to CDash. It does not enable CTest for running the test suite. You still have to use `./runTests`.

This is part of my work on the DoE PESO project.