### PR TITLE
Free Dyninst lock before unloading the RT library in test_thread_1

### DIFF
--- a/src/dyninst/test_thread_1_mutatee.c
+++ b/src/dyninst/test_thread_1_mutatee.c
@@ -142,9 +142,11 @@ int func1_1() {
     pthread_join(test1threads[i], NULL);
   }
 
+  /* The lock must be freed before dlclose: DYNINSTfree_thelock points into
+   * the RT library and is invalid once the library is unmapped. */
+  DYNINSTfree_thelock(&test1lock);
   dlclose(RTlib);
   pthread_barrier_destroy(&startup_barrier);
-  DYNINSTfree_thelock(&test1lock);
 
   return subtest1err;
 }


### PR DESCRIPTION
func1_1() called dlclose(RTlib) before invoking DYNINSTfree_thelock, which is a function pointer resolved via dlsym into that same library. If the dlopen'd handle was the last reference (i.e., it did not resolve to the copy Dyninst injected), dlclose unmaps the library and the subsequent call jumps into unmapped memory, crashing the mutatee with SIGSEGV. This matches the sporadic signal-11 failures seen for test_thread_1.

Free the lock while the library is still mapped, then dlclose.