### PR TITLE
ppc: build test mutators against the ppc64 register namespace

### DIFF
--- a/src/instruction/power_decode.C
+++ b/src/instruction/power_decode.C
@@ -32,7 +32,6 @@
 #include "instruction_comp.h"
 #include "InstructionDecoder.h"
 #include "Register.h"
-#include "registers/ppc32_regs.h"
 #include "registers/ppc64_regs.h"
 #include "test_lib.h"
 
@@ -59,7 +58,7 @@ extern "C" DLLEXPORT TestMutator* power_decode_factory() {
 test_results_t power_decode_Mutator::executeTest() {
 
   // Decoding in 64-bit mode uses 32-bit registers
-  auto const arch = Dyninst::Arch_ppc32;
+  auto const arch = Dyninst::Arch_ppc64;
 
   constexpr auto num_tests = 27;
 
@@ -112,34 +111,34 @@ test_results_t power_decode_Mutator::executeTest() {
     }
   }
 
-  RegisterAST::Ptr r0(new RegisterAST(ppc32::r0));
-  RegisterAST::Ptr r1(new RegisterAST(ppc32::r1));
-  RegisterAST::Ptr r2(new RegisterAST(ppc32::r2));
-  RegisterAST::Ptr r5(new RegisterAST(ppc32::r5));
-  RegisterAST::Ptr r7(new RegisterAST(ppc32::r7));
-  RegisterAST::Ptr r8(new RegisterAST(ppc32::r8));
-  RegisterAST::Ptr r9(new RegisterAST(ppc32::r9));
-  RegisterAST::Ptr cr0(new RegisterAST(ppc32::cr0));
-  RegisterAST::Ptr cr2(new RegisterAST(ppc32::cr2));
-  RegisterAST::Ptr cr4(new RegisterAST(ppc32::cr4));
-  RegisterAST::Ptr cr6(new RegisterAST(ppc32::cr6));
-  RegisterAST::Ptr cr7(new RegisterAST(ppc32::cr7));
-  RegisterAST::Ptr xer(new RegisterAST(ppc32::xer));
-  RegisterAST::Ptr fpr0(new RegisterAST(ppc32::fpr0));
-  RegisterAST::Ptr fpr1(new RegisterAST(ppc32::fpr1));
-  RegisterAST::Ptr fpr2(new RegisterAST(ppc32::fpr2));
-  RegisterAST::Ptr fsr0(new RegisterAST(ppc32::fsr0));
-  RegisterAST::Ptr fsr1(new RegisterAST(ppc32::fsr1));
-  RegisterAST::Ptr fsr2(new RegisterAST(ppc32::fsr2));
-  RegisterAST::Ptr fpscw(new RegisterAST(ppc32::fpscw));
-  RegisterAST::Ptr fpscw0(new RegisterAST(ppc32::fpscw0));
-  RegisterAST::Ptr fpscw2(new RegisterAST(ppc32::fpscw2));
-  RegisterAST::Ptr fpscw4(new RegisterAST(ppc32::fpscw4));
-  RegisterAST::Ptr fpscw6(new RegisterAST(ppc32::fpscw6));
-  RegisterAST::Ptr fpscw7(new RegisterAST(ppc32::fpscw7));
-  RegisterAST::Ptr pc(new RegisterAST(ppc32::pc));
-  RegisterAST::Ptr ctr(new RegisterAST(ppc32::ctr));
-  RegisterAST::Ptr lr(new RegisterAST(ppc32::lr));
+  RegisterAST::Ptr r0(new RegisterAST(ppc64::r0));
+  RegisterAST::Ptr r1(new RegisterAST(ppc64::r1));
+  RegisterAST::Ptr r2(new RegisterAST(ppc64::r2));
+  RegisterAST::Ptr r5(new RegisterAST(ppc64::r5));
+  RegisterAST::Ptr r7(new RegisterAST(ppc64::r7));
+  RegisterAST::Ptr r8(new RegisterAST(ppc64::r8));
+  RegisterAST::Ptr r9(new RegisterAST(ppc64::r9));
+  RegisterAST::Ptr cr0(new RegisterAST(ppc64::cr0));
+  RegisterAST::Ptr cr2(new RegisterAST(ppc64::cr2));
+  RegisterAST::Ptr cr4(new RegisterAST(ppc64::cr4));
+  RegisterAST::Ptr cr6(new RegisterAST(ppc64::cr6));
+  RegisterAST::Ptr cr7(new RegisterAST(ppc64::cr7));
+  RegisterAST::Ptr xer(new RegisterAST(ppc64::xer));
+  RegisterAST::Ptr fpr0(new RegisterAST(ppc64::fpr0));
+  RegisterAST::Ptr fpr1(new RegisterAST(ppc64::fpr1));
+  RegisterAST::Ptr fpr2(new RegisterAST(ppc64::fpr2));
+  RegisterAST::Ptr fsr0(new RegisterAST(ppc64::fsr0));
+  RegisterAST::Ptr fsr1(new RegisterAST(ppc64::fsr1));
+  RegisterAST::Ptr fsr2(new RegisterAST(ppc64::fsr2));
+  RegisterAST::Ptr fpscw(new RegisterAST(ppc64::fpscw));
+  RegisterAST::Ptr fpscw0(new RegisterAST(ppc64::fpscw0));
+  RegisterAST::Ptr fpscw2(new RegisterAST(ppc64::fpscw2));
+  RegisterAST::Ptr fpscw4(new RegisterAST(ppc64::fpscw4));
+  RegisterAST::Ptr fpscw6(new RegisterAST(ppc64::fpscw6));
+  RegisterAST::Ptr fpscw7(new RegisterAST(ppc64::fpscw7));
+  RegisterAST::Ptr pc(new RegisterAST(ppc64::pc));
+  RegisterAST::Ptr ctr(new RegisterAST(ppc64::ctr));
+  RegisterAST::Ptr lr(new RegisterAST(ppc64::lr));
 
   std::vector<registerSet> expectedRead, expectedWritten;
 

--- a/src/proccontrol/pc_irpc_asm.h
+++ b/src/proccontrol/pc_irpc_asm.h
@@ -66,29 +66,6 @@ static void createBuffer(Process::ptr proc,
          start_offset = 4;
          break;
       }
-      case Dyninst::Arch_ppc32: {
-         buffer_size = 6*4;
-         buffer = (unsigned char *)malloc(buffer_size);
-         uint32_t addr32 = (uint32_t) calltarg;
-         // nop
-         buffer[0] = 0x60; buffer[1] = 0x00; buffer[2] = 0x00; buffer[3] = 0x00;
-         // lis r0, 0
-         buffer[4] = 0x3c; buffer[5] = 0x00; buffer[6] = 0x00; buffer[7] = 0x00;
-         // ori r0, r0, 0
-         buffer[8] = 0x60; buffer[9] = 0x00; buffer[10] = 0x00; buffer[11] = 0x00;
-         // mtctr r0
-         buffer[12] = 0x7c; buffer[13] = 0x09; buffer[14] = 0x03; buffer[15] = 0xa6;
-         // bctrl
-         buffer[16] = 0x4e; buffer[17] = 0x80; buffer[18] = 0x04; buffer[19] = 0x21;
-         // trap
-         buffer[20] = 0x7d; buffer[21] = 0x82; buffer[22] = 0x10; buffer[23] = 0x08;
-         start_offset = 4;
-
-         // copy address into buffer
-         *((uint16_t *) (buffer + 6)) = (uint16_t)(addr32 >> 16);
-         *((uint16_t *) (buffer + 10)) = (uint16_t)addr32;
-         break;
-      }
       case Dyninst::Arch_ppc64: {
          //
          // Since PPC opcodes are all 32 bits, work with them in their native


### PR DESCRIPTION
The PowerPC instruction decoder and process-control stack move entirely to the ppc64 register namespace (ppc32 is unsupported; its enum value Arch_ppc32 and its register namespace are removed). Two test sources still referenced them and no longer compile:

  - instruction/power_decode.C decoded with Arch_ppc32 and compared results against ppc32:: register ASTs. Switch both to Arch_ppc64 / ppc64:: so the expected registers match what the decoder now emits.
  - proccontrol/pc_irpc_asm.h carried an Arch_ppc32 iRPC code-generation case referencing the removed enumerator. Drop it (ppc32 is unsupported).

Depends on the Dyninst change that removes Arch_ppc32 and emits ppc64-namespace registers from the PowerPC decoder; build and run this on ppc64 together with it.